### PR TITLE
Remove END_TAG

### DIFF
--- a/doc/edmConverters.md
+++ b/doc/edmConverters.md
@@ -98,11 +98,11 @@ Output_DST.OutputLevel = WARNING
 # 2
 Output_DST.ProcessorType = "LCIOOutputProcessor"
 # 3
-Output_DST.Parameters = [
-                         "DropCollectionNames", END_TAG,
-                         "DropCollectionTypes", "MCParticle", "LCRelation", "SimCalorimeterHit",
+Output_DST.Parameters = {
+                         "DropCollectionNames": [],
+                         "DropCollectionTypes": ["MCParticle", "LCRelation", "SimCalorimeterHit"],
                          ...
-                         ]
+                         }
 
 # 4                         
 algList.append(Output_DST)                         

--- a/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
@@ -78,13 +78,12 @@ private:
 
   /// Parse the parameters from the Property
   std::shared_ptr<marlin::StringParameters> parseParameters(
-    const Gaudi::Property<std::vector<std::string>>& parameters,
+    const Gaudi::Property<std::map<std::string, std::vector<std::string>>>& parameters,
     std::string& verbosity) const;
 
   /// ProcessorType: The Type of the MarlinProcessor to use
   Gaudi::Property<std::string> m_processorType{this, "ProcessorType", {}};
-  /// Parameters: Dictionary of key and list of strings would be nice, but we just use a vector of strings for the moment
-  Gaudi::Property<std::vector<std::string>> m_parameters{this, "Parameters", {}};
+  Gaudi::Property<std::map<std::string, std::vector<std::string>>> m_parameters{this, "Parameters", {}};
 
   ToolHandle<IEDMConverter> m_edm_conversionTool{"IEDMConverter/EDM4hep2Lcio", this};
   ToolHandle<IEDMConverter> m_lcio_conversionTool{"IEDMConverter/Lcio2EDM4hep", this};

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -176,7 +176,7 @@ def createHeader(lines):
   lines.append("from k4MarlinWrapper.parseConstants import *")
   lines.append("algList = []")
   lines.append("evtsvc = EventDataSvc()\n")
-  lines.append("END_TAG = \"END_TAG\"\n")
+  # lines.append("END_TAG = \"END_TAG\"\n")
 
 
 def createLcioReader(lines, glob):
@@ -217,20 +217,16 @@ def convertParamters(params, proc, globParams, constants):
   lines = []
   lines.append("%s.OutputLevel = %s " % (proc.replace(".", "_"), verbosityTranslator(globParams.get("Verbosity"))))
   lines.append("%s.ProcessorType = \"%s\" " % (proc.replace(".", "_"), params.get("type")))
-  lines.append("%s.Parameters = [" % proc.replace(".", "_"))
+  lines.append("%s.Parameters = {" % proc.replace(".", "_"))
   for para in sorted(params):
     if para not in ["type", "Verbosity"]:
       value = params[para].replace('\n', ' ')
       value = " ".join(value.split())
-
-      if not value:
-        lines.append("%s\"%s\", END_TAG," % (' ' * (len(proc) + 15), para))
-      else:
-        lines.append("%s\"%s\", %s, END_TAG," % \
-          (' ' * (len(proc) + 15), para, replaceConstants(value, constants)))
+      lines.append("%s\"%s\": [%s]," % \
+        (' ' * (len(proc) + 15), para, replaceConstants(value, constants)))
 
   lines[-1] = lines[-1][:-1]
-  lines.append("%s]\n" % (' ' * (len(proc) + 15)))
+  lines.append("%s}\n" % (' ' * (len(proc) + 15)))
   return lines
 
 

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -109,10 +109,10 @@ std::shared_ptr<marlin::StringParameters> MarlinProcessorWrapper::parseParameter
 {
   auto parameters_ptr = std::make_shared<marlin::StringParameters>();
   info() << "Parameter values for: " << name() << " of type " << std::string(m_processorType) << endmsg;
-  std::vector<std::string> parameterValues = {};
 
   // convert the list of string into parameter name and value
   for (const auto& [paramName, paramValues] : parameters) {
+    std::vector<std::string> parameterValues = {};
     if (paramName == "Verbosity") {
       info() << "Setting verbosity to " << paramName << endmsg;
       verbosity = paramName;
@@ -125,7 +125,6 @@ std::shared_ptr<marlin::StringParameters> MarlinProcessorWrapper::parseParameter
     }
 
     parameters_ptr->add(paramName, parameterValues);
-    parameterValues.clear();
   }
 
   return parameters_ptr;

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -109,12 +109,23 @@ std::shared_ptr<marlin::StringParameters> MarlinProcessorWrapper::parseParameter
 {
   auto parameters_ptr = std::make_shared<marlin::StringParameters>();
   info() << "Parameter values for: " << name() << " of type " << std::string(m_processorType) << endmsg;
-  std::string              parameterName   = "";
   std::vector<std::string> parameterValues = {};
 
   // convert the list of string into parameter name and value
   for (const auto& [paramName, paramValues] : parameters) {
-    parameters_ptr->add(paramName, paramValues);
+    if (paramName == "Verbosity") {
+      info() << "Setting verbosity to " << paramName << endmsg;
+      verbosity = paramName;
+    }
+
+    for (auto& value : paramValues) {
+      // split to keep track of case where constants replacing merges various params into one string
+      auto split_parameter = k4MW::util::split(value);
+      parameterValues.insert(parameterValues.end(), split_parameter.begin(), split_parameter.end());
+    }
+
+    parameters_ptr->add(paramName, parameterValues);
+    parameterValues.clear();
   }
 
   return parameters_ptr;

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -104,7 +104,7 @@ StatusCode MarlinProcessorWrapper::loadProcessorLibraries() const {
 
 
 std::shared_ptr<marlin::StringParameters> MarlinProcessorWrapper::parseParameters(
-  const Gaudi::Property<std::vector<std::string>>& parameters,
+  const Gaudi::Property<std::map<std::string, std::vector<std::string>>>& parameters,
   std::string& verbosity) const
 {
   auto parameters_ptr = std::make_shared<marlin::StringParameters>();
@@ -113,38 +113,13 @@ std::shared_ptr<marlin::StringParameters> MarlinProcessorWrapper::parseParameter
   std::vector<std::string> parameterValues = {};
 
   // convert the list of string into parameter name and value
-  for (const auto& parameterString : parameters) {
-    if (parameterString == "END_TAG") {
-      parameters_ptr->add(parameterName, parameterValues);
-
-      info() << parameterName;
-      for (const auto& value : parameterValues) {
-        info() << "  " << value;
-      }
-      info() << endmsg;
-      if (parameterName == "Verbosity") {
-        info() << "Setting verbosity to " << parameterValues[0] << endmsg;
-        verbosity = parameterValues[0];
-      }
-
-      parameterName = "";
-      parameterValues.clear();
-
-      continue;
-    }
-
-    if (parameterName == "") {
-      parameterName = parameterString;
-      continue;
-    }
-
-    auto split_parameter = k4MW::util::split(parameterString);
-    parameterValues.insert(parameterValues.end(), split_parameter.begin(), split_parameter.end());
-
+  for (const auto& [paramName, paramValues] : parameters) {
+    parameters_ptr->add(paramName, paramValues);
   }
 
   return parameters_ptr;
 }
+
 
 StatusCode MarlinProcessorWrapper::instantiateProcessor(
   std::shared_ptr<marlin::StringParameters>& parameters,

--- a/test/gaudi_opts/test_k4MarlinWrapper1.py
+++ b/test/gaudi_opts/test_k4MarlinWrapper1.py
@@ -10,53 +10,52 @@ read.OutputLevel = DEBUG
 read.Files = ["$k4MarlinWrapper_tests_DIR/inputFiles/muons.slcio"]
 algList.append(read)
 
-END_TAG = "END_TAG"
-
 # assign parameters by hand, in future parse Marlin.xml file in python
 # and convert to list of processors and parameters
 procA = MarlinProcessorWrapper("AidaProcessor")
 procA.OutputLevel = DEBUG
 procA.ProcessorType = "AIDAProcessor"
-procA.Parameters = ["FileName", "histograms", END_TAG,
-                    "FileType", "root", END_TAG,
-                    "Compress", "1", END_TAG,
-                    "Verbosity", "DEBUG", END_TAG,
-                    ]
+procA.Parameters = {"FileName": ["histograms"],
+                    "FileType": ["root"],
+                    "Compress": ["1"],
+                    "Verbosity": ["DEBUG"],
+                    }
 algList.append(procA)
 
 
 proc0 = MarlinProcessorWrapper("EventNumber")
 proc0.OutputLevel = DEBUG
 proc0.ProcessorType = "Statusmonitor"
-proc0.Parameters = ["HowOften", "1", END_TAG,
-                    "Verbosity", "DEBUG", END_TAG,
-                    ]
+proc0.Parameters = {"HowOften": ["1"],
+                    "Verbosity": ["DEBUG"],
+                    }
 algList.append(proc0)
 
 
 proc1 = MarlinProcessorWrapper("InitDD4hep")
 proc1.OutputLevel = DEBUG
 proc1.ProcessorType = "InitializeDD4hep"
-proc1.Parameters = [#"EncodingStringParameter", "GlobalTrackerReadoutID", END_TAG,
+proc1.Parameters = {#"EncodingStringParameter", "GlobalTrackerReadoutID", END_TAG,
                     #"DD4hepXMLFile", "/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml", END_TAG,
-                    "DD4hepXMLFile", "/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml", END_TAG,
-                    ]
+                    "DD4hepXMLFile": ["/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml"],
+                    }
 algList.append(proc1)
 
 
 digiVxd = MarlinProcessorWrapper("VXDBarrelDigitiser")
 digiVxd.OutputLevel = DEBUG
 digiVxd.ProcessorType = "DDPlanarDigiProcessor"
-digiVxd.Parameters = [
-    "SubDetectorName", "Vertex", END_TAG,
-    "IsStrip", "false", END_TAG,
-    "ResolutionU", "0.003", "0.003", "0.003", "0.003", "0.003", "0.003", END_TAG,
-    "ResolutionV", "0.003", "0.003", "0.003", "0.003", "0.003", "0.003", END_TAG,
-    "SimTrackHitCollectionName", "VertexBarrelCollection", END_TAG,
-    "SimTrkHitRelCollection", "VXDTrackerHitRelations", END_TAG,
-    "TrackerHitCollectionName", "VXDTrackerHits", END_TAG,
-    "Verbosity" , "DEBUG", END_TAG,
-                    ]
+digiVxd.Parameters = {
+    "SubDetectorName": ["Vertex"],
+    "IsStrip": ["false"],
+    "ResolutionU": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
+    "ResolutionV": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
+    "SimTrackHitCollectionName": ["VertexBarrelCollection"],
+    "SimTrkHitRelCollection": ["VXDTrackerHitRelations"],
+    "TrackerHitCollectionName": ["VXDTrackerHits"],
+    "Verbosity": ["DEBUG"],
+                    }
+
 algList.append(digiVxd)
 
 

--- a/test/gaudi_opts/test_k4MarlinWrapper2.py
+++ b/test/gaudi_opts/test_k4MarlinWrapper2.py
@@ -10,68 +10,66 @@ read.OutputLevel = DEBUG
 read.Files = ["$k4MarlinWrapper_tests_DIR/inputFiles/testSimulation.slcio"]
 algList.append(read)
 
-END_TAG = "END_TAG"
-
 # assign parameters by hand, in future parse Marlin.xml file in python
 # and convert to list of processors and parameters
 procA = MarlinProcessorWrapper("AidaProcessor")
 procA.OutputLevel = DEBUG
 procA.ProcessorType = "AIDAProcessor"
-procA.Parameters = ["FileName", "histograms", END_TAG,
-                    "FileType", "root", END_TAG,
-                    "Compress", "1", END_TAG,
-                    "Verbosity", "DEBUG", END_TAG,
-                    ]
+procA.Parameters = {"FileName": ["histograms"],
+                    "FileType": ["root"],
+                    "Compress": ["1"],
+                    "Verbosity": ["DEBUG"],
+                    }
 algList.append(procA)
 
 
 proc0 = MarlinProcessorWrapper("EventNumber")
 proc0.OutputLevel = DEBUG
 proc0.ProcessorType = "Statusmonitor"
-proc0.Parameters = ["HowOften", "1", END_TAG,
-                    "Verbosity", "DEBUG", END_TAG,
-                    ]
+proc0.Parameters = {"HowOften": ["1"],
+                    "Verbosity": ["DEBUG"],
+                    }
 algList.append(proc0)
 
 
 proc1 = MarlinProcessorWrapper("InitDD4hep")
 proc1.OutputLevel = DEBUG
 proc1.ProcessorType = "InitializeDD4hep"
-proc1.Parameters = [#"EncodingStringParameter", "GlobalTrackerReadoutID", END_TAG,
-                    #"DD4hepXMLFile", "/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml", END_TAG,
-                    "DD4hepXMLFile", "/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml", END_TAG,
-                    ]
+proc1.Parameters = {#"EncodingStringParameter": ["GlobalTrackerReadoutID"],
+                    #"DD4hepXMLFile": ["/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml"],
+                    "DD4hepXMLFile": ["/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml"],
+                    }
 algList.append(proc1)
 
 
 digiVxd = MarlinProcessorWrapper("VXDBarrelDigitiser")
 digiVxd.OutputLevel = DEBUG
 digiVxd.ProcessorType = "DDPlanarDigiProcessor"
-digiVxd.Parameters = [
-    "SubDetectorName", "Vertex", END_TAG,
-    "IsStrip", "false", END_TAG,
-    "ResolutionU", "0.003", "0.003", "0.003", "0.003", "0.003", "0.003", END_TAG,
-    "ResolutionV", "0.003", "0.003", "0.003", "0.003", "0.003", "0.003", END_TAG,
-    "SimTrackHitCollectionName", "VertexBarrelCollection", END_TAG,
-    "SimTrkHitRelCollection", "VXDTrackerHitRelations", END_TAG,
-    "TrackerHitCollectionName", "VXDTrackerHits", END_TAG,
-    "Verbosity" , "DEBUG", END_TAG,
-                    ]
+digiVxd.Parameters = {
+    "SubDetectorName": ["Vertex"],
+    "IsStrip": ["false"],
+    "ResolutionU": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
+    "ResolutionV": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
+    "SimTrackHitCollectionName": ["VertexBarrelCollection"],
+    "SimTrkHitRelCollection": ["VXDTrackerHitRelations"],
+    "TrackerHitCollectionName": ["VXDTrackerHits"],
+    "Verbosity": ["DEBUG"],
+                    }
 algList.append(digiVxd)
 
 digiVxd2 = MarlinProcessorWrapper("VXDBarrelDigitiser2")
 digiVxd2.OutputLevel = DEBUG
 digiVxd2.ProcessorType = "DDPlanarDigiProcessor"
-digiVxd2.Parameters = [
-    "SubDetectorName", "Vertex", END_TAG,
-    "IsStrip", "false", END_TAG,
-    "ResolutionU", "0.002", "0.002", "0.002", "0.002", "0.002", "0.002", END_TAG,
-    "ResolutionV", "0.001", "0.001", "0.001", "0.001", "0.001", "0.001", END_TAG,
-    "SimTrackHitCollectionName", "VertexBarrelCollection2", END_TAG,
-    "SimTrkHitRelCollection", "VXDTrackerHitRelations2", END_TAG,
-    "TrackerHitCollectionName", "VXDTrackerHits2", END_TAG,
-    "Verbosity" , "DEBUG", END_TAG,
-                    ]
+digiVxd2.Parameters = {
+    "SubDetectorName": ["Vertex"],
+    "IsStrip": ["false"],
+    "ResolutionU": ["0.002", "0.002", "0.002", "0.002", "0.002", "0.002"],
+    "ResolutionV": ["0.001", "0.001", "0.001", "0.001", "0.001", "0.001"],
+    "SimTrackHitCollectionName": ["VertexBarrelCollection2"],
+    "SimTrkHitRelCollection": ["VXDTrackerHitRelations2"],
+    "TrackerHitCollectionName": ["VXDTrackerHits2"],
+    "Verbosity": ["DEBUG"],
+                    }
 algList.append(digiVxd2)
 
 from Configurables import ApplicationMgr

--- a/test/scripts/test_clicReconstruction.sh
+++ b/test/scripts/test_clicReconstruction.sh
@@ -27,7 +27,7 @@ echo "Modifying clicReconstruction.py file..."
 sed -i 's|/run/simulation/with/ctest/to/create/a/file.slcio|$k4MarlinWrapper_tests_DIR/inputFiles/testSimulation.slcio|g' clicReconstruction.py
 # Uncomment selected optional processors
 sed -i 's;EvtMax   = 10,;EvtMax   = 3,;' clicReconstruction.py
-sed -i 's;"MaxRecordNumber", "10", END_TAG,;"MaxRecordNumber", "3", END_TAG,;' clicReconstruction.py
+sed -i 's;"MaxRecordNumber": ["10"],;"MaxRecordNumber": ["3"],;' clicReconstruction.py
 sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReconstruction.py
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py


### PR DESCRIPTION
BEGINRELEASENOTES
- !! Breaking change!!
- Remove the need for an END_TAG in the options file: replace it with a map/dict of key-values
- Adapt XML to Python converter to fit for the change
- Adapt tests with new format

ENDRELEASENOTES
