### PR TITLE
Add starterkit page from key4hep-doc

### DIFF
--- a/.github/scripts/yamlheader.md
+++ b/.github/scripts/yamlheader.md
@@ -1,0 +1,8 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -1,0 +1,49 @@
+name: doctest-linux
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SETUP: ['/cvmfs/sw.hsf.org/key4hep/setup.sh', '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
+        PAGE: ['doc/starterkit/k4MarlinWrapperCLIC/Readme', ]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - name: Start container
+      run: |
+        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg /bin/bash
+    - name: Setup container
+      run: |
+        docker exec CI_container /bin/bash -c ' ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so;\
+        source ${{ matrix.SETUP }};\
+        pip3 install jupytext;\
+        pip3 install --upgrade jupyter;\
+        python -m ipykernel install --name python3;\
+        python -m ipykernel install --name bash;\
+        '
+
+    - name: Compile
+      run: |
+        docker exec CI_container /bin/bash -c ' cd Package;/
+        source ${{ matrix.SETUP }};\
+        mkdir build; cd build;\
+        cmake .. ;\
+        make -j 2;\
+        '
+
+    - name: CheckPage  
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+        source ${{ matrix.SETUP }};\
+        source build/k4marlinwrapperenv.sh;\
+        export PATH=$HOME/.local/bin/:$PATH;\
+        cat .github/scripts/yamlheader.md  ${{ matrix.PAGE }}.md > ${{ matrix.PAGE }}-test.md;\
+        testfilename=$(basename ${{ matrix.PAGE }}-test.md);\
+        testdirname=$(dirname ${{ matrix.PAGE }}-test.md);\
+        cd $testdirname;\
+        jupytext $testfilename -o ${testfilename/-test.md/.ipynb} --execute;\
+        '

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -1,0 +1,86 @@
+# Using the Key4hep-Stack for CLIC Simulation and Reconstruction
+
+
+This assumes that you have access to an installation of the Key4hep-stack, either via ``CVMFS`` or ``spack install``.
+To setup the installation on cvmfs, do:
+
+```
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
+```
+
+These commands will explain how one can run the CLIC detector simulation and reconstruction using the Key4hep-Stack.
+First we will obtain all the necessary steering and input files for CLIC, simulate a few events and run the
+reconstruction both with ``Marlin`` and ``k4run``. These steps can be adapted to simulate or run other ``Marlin``
+processors as well.
+
+The ``CLICPerformance`` repository contains the steering and input files.
+
+```bash
+git clone https://github.com/iLCSoft/CLICPerformance
+```
+
+## Simulation
+
+Now we can already simulate a few events:
+
+```bash
+cd CLICPerformance/clicConfig
+
+ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+      --outputFile ttbar.slcio \
+      --steeringFile clic_steer.py \
+      --inputFiles ../Tests/yyxyev_000.stdhep \
+      --numberOfEvents 3
+```
+
+## Reconstruction
+
+### Reconstruction with Marlin
+
+To run the reconstruction with ``Marlin``:
+
+```bash
+cd CLICPerformance/clicConfig
+
+Marlin clicReconstruction.xml \
+       --InitDD4hep.DD4hepXMLFile=$LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+       --global.LCIOInputFiles=ttbar.slcio \
+       --global.MaxRecordNumber=3
+```
+
+### Reconstruction with with Gaudi
+
+We can convert the ``xml`` steering file to a Gaudi steering file
+
+```bash
+cd CLICPerformance/clicConfig
+
+convertMarlinSteeringToGaudi.py clicReconstruction.xml clicReconstruction.py
+```
+
+Now we need to modify the ``clicReconstruction.py`` file to point to the ``ttbar.slcio`` input file, and change the
+``DD4hepXMLFile`` parameter for the ``InitDD4hep`` algorithm.  In addition the two processors with the comment ``#
+Config.OverlayFalse`` and ``# Config.TrackingConformal`` should be enabled by uncommenting their line in the ``algList``
+at the end of the file.
+
+```bash
+cd CLICPerformance/clicConfig
+
+sed -i 's;read.Files = \[".*"\];read.Files = \["ttbar.slcio"\];' clicReconstruction.py
+sed -i 's;EvtMax   = 10,;EvtMax   = 3,;' clicReconstruction.py
+sed -i 's;"MaxRecordNumber": ["10"],;"MaxRecordNumber": ["3"],;' clicReconstruction.py
+sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReconstruction.py
+sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
+sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
+sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
+
+```
+
+Then the reconstruction using the wrapper can be run with
+
+```bash
+cd CLICPerformance/clicConfig
+
+k4run clicReconstruction.py
+```

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -73,7 +73,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile": \[".*"\],; "DD4hepXMLFile": \[os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\],;' clicReconstruction.py
 
 ```
 

--- a/test/scripts/test_clicReconstruction.sh
+++ b/test/scripts/test_clicReconstruction.sh
@@ -32,7 +32,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile": \[".*"\],; "DD4hepXMLFile": \[os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\],;' clicReconstruction.py
 # Change output level for correct test confirmation
 sed -i 's;OutputLevel=WARNING; OutputLevel=DEBUG;' clicReconstruction.py
 


### PR DESCRIPTION
This should help keep the documentation in sync.

Once this is merged, I'll fetch from here in the key4hep-doc repo (as discussed here: https://github.com/key4hep/key4hep-doc/issues/13)

Once I manage to install jupytext on cvmfs, the test should also have less overhead.

BEGINRELEASENOTES
- Add starterkit page from key4hep-doc, with test workflow
ENDRELEASENOTES
