### PR TITLE
Automatically convert some related collections (LCIO->EDM4hep)

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/IEDMConverter.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/IEDMConverter.h
@@ -21,6 +21,8 @@
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/CaloHitContribution.h>
+#include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/TPCHit.h>
 #include <edm4hep/TPCHitCollection.h>
 #include <edm4hep/Cluster.h>

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -115,13 +115,11 @@ StatusCode Lcio2EDM4hepTool::convertCollections(
       } else if (coll_type_str == "SimCalorimeterHit") {
         convertPut<edm4hep::SimCalorimeterHitCollection>(
           m_lcio2edm_params[i+1], m_lcio2edm_params[i], lcio_converter, id_table);
+        // Get associated collections
+        // This collection name is hardcoded in k4LCIOConverter
+        convertPut<edm4hep::CaloHitContributionCollection>(
+          "CaloHitContribution_EXT", "CaloHitContribution_EXT", lcio_converter, id_table);
       } else if (coll_type_str == "RawCalorimeterHit") {
-          m_lcio2edm_params[i+2], m_lcio2edm_params[i+1], lcio_converter, id_table);
-          // Get associated collections
-          // These collection names are hardcoded in k4LCIOConverter
-          convertPut<edm4hep::CaloHitContributionCollection>(
-            "CaloHitContribution_EXT", "CaloHitContribution_EXT", lcio_converter, id_table);
-      } else if (m_lcio2edm_params[i] == "RawCalorimeterHit") {
         convertPut<edm4hep::RawCalorimeterHitCollection>(
           m_lcio2edm_params[i+1], m_lcio2edm_params[i], lcio_converter, id_table);
       } else if (coll_type_str == "TPCHit") {

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -116,6 +116,12 @@ StatusCode Lcio2EDM4hepTool::convertCollections(
         convertPut<edm4hep::SimCalorimeterHitCollection>(
           m_lcio2edm_params[i+1], m_lcio2edm_params[i], lcio_converter, id_table);
       } else if (coll_type_str == "RawCalorimeterHit") {
+          m_lcio2edm_params[i+2], m_lcio2edm_params[i+1], lcio_converter, id_table);
+          // Get associated collections
+          // These collection names are hardcoded in k4LCIOConverter
+          convertPut<edm4hep::CaloHitContributionCollection>(
+            "CaloHitContribution_EXT", "CaloHitContribution_EXT", lcio_converter, id_table);
+      } else if (m_lcio2edm_params[i] == "RawCalorimeterHit") {
         convertPut<edm4hep::RawCalorimeterHitCollection>(
           m_lcio2edm_params[i+1], m_lcio2edm_params[i], lcio_converter, id_table);
       } else if (coll_type_str == "TPCHit") {


### PR DESCRIPTION
BEGINRELEASENOTES
- convert calohitcontributions for SimCaloHits, re-use table of collect…

ENDRELEASENOTES

Some collections are automatically converted in k4LCIOReader, but not in k4MarlinWrapper.
