### PR TITLE
[cmake] use BUILD_TESTING to make tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ find_package(k4LCIOReader)
 include(CTest)
 
 add_subdirectory(k4MarlinWrapper)
-add_subdirectory(test)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 gaudi_install(CMAKE)


### PR DESCRIPTION
BEGINRELEASENOTES
- [cmake] use BUILD_TESTING to make tests optional

ENDRELEASENOTES
