### PR TITLE
[cmake] fix wrong include for targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,16 +48,12 @@ include(cmake/compiler_output.cmake)
 
 include(GNUInstallDirs)
 
-find_package(ROOT 6.0 REQUIRED)
+find_package(Gaudi REQUIRED)
 find_package(LCIO REQUIRED)
 find_package(Marlin REQUIRED)
-find_package(Gaudi REQUIRED)
-
-find_package(k4FWCore)
-find_package(podio)
-find_package(EDM4HEP)
-
-find_package(k4LCIOReader)
+find_package(EDM4HEP REQUIRED)
+find_package(k4FWCore REQUIRED)
+find_package(k4LCIOReader REQUIRED)
 
 include(CTest)
 

--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -28,16 +28,10 @@ gaudi_add_module(k4MarlinWrapperPlugins
     src/components/LcioEventAlgo.cpp
   LINK
     Gaudi::GaudiAlgLib
-    Gaudi::GaudiKernel
-    ROOT::Core
-    ${LCIO_LIBRARIES}
-    ${Marlin_LIBRARIES}
 )
 
 target_include_directories(k4MarlinWrapperPlugins PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
-  ${LCIO_INCLUDE_DIRS}
-  ${Marlin_INCLUDE_DIRS}
 )
 
 # MarlinWrapper
@@ -46,16 +40,11 @@ gaudi_add_module(MarlinWrapper
     src/components/MarlinProcessorWrapper.cpp
   LINK
     Gaudi::GaudiAlgLib
-    Gaudi::GaudiKernel
-    ${LCIO_LIBRARIES}
     ${Marlin_LIBRARIES}
-    k4LCIOReader::k4LCIOReader
 )
 
 target_include_directories(MarlinWrapper PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
-  ${LCIO_INCLUDE_DIRS}
-  ${Marlin_INCLUDE_DIRS}
 )
 
 # EDM4hep2lcio
@@ -64,7 +53,6 @@ gaudi_add_module(EDM4hep2Lcio
     src/components/EDM4hep2Lcio.cpp
   LINK
     Gaudi::GaudiAlgLib
-    Gaudi::GaudiKernel
     ${LCIO_LIBRARIES}
     k4FWCore::k4FWCore
     EDM4HEP::edm4hep
@@ -72,7 +60,6 @@ gaudi_add_module(EDM4hep2Lcio
 
 target_include_directories(EDM4hep2Lcio PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
-  ${LCIO_INCLUDE_DIRS}
 )
 
 # LCIO2EDM4hep
@@ -81,8 +68,6 @@ gaudi_add_module(Lcio2EDM4hep
     src/components/Lcio2EDM4hep.cpp
   LINK
     Gaudi::GaudiAlgLib
-    Gaudi::GaudiKernel
-    ${LCIO_LIBRARIES}
     EDM4HEP::edm4hep
     k4FWCore::k4FWCore
     k4LCIOReader::k4LCIOReader
@@ -90,5 +75,4 @@ gaudi_add_module(Lcio2EDM4hep
 
 target_include_directories(Lcio2EDM4hep PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
-  ${LCIO_INCLUDE_DIRS}
 )

--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -72,8 +72,6 @@ gaudi_add_module(EDM4hep2Lcio
 
 target_include_directories(EDM4hep2Lcio PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
-  k4FWCore::k4FWCore
-  EDM4HEP::edm4hep
   ${LCIO_INCLUDE_DIRS}
 )
 
@@ -92,7 +90,5 @@ gaudi_add_module(Lcio2EDM4hep
 
 target_include_directories(Lcio2EDM4hep PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
-  k4FWCore::k4FWCore
-  EDM4HEP::edm4hep
   ${LCIO_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Just noticed that this causes some nonsensical includes like `-I/tmp/arch/spack-stage/spack-stage-k4marlinwrapper-0.4-kahcs4rkiy7umpchldefwqigzdvy6fst/spack-src/test/EDM4HEP::edm4hep`.

Linking the target should be enough.

BEGINRELEASENOTES
- [cmake] fix wrong include for targets

ENDRELEASENOTES
