### PR TITLE
remove calls to getreadcollections to comply with updated k4fwcore

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -936,17 +936,7 @@ void EDM4hep2LcioTool::FillMissingCollections(CollectionsPairVectors& collection
 void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::string& lcio_coll_name,
                                   lcio::LCEventImpl* lcio_event, CollectionsPairVectors& collection_pairs) {
   // Get the associated type to the collection name
-  auto evt_store_read = m_podioDataSvc->getReadCollections();
   auto evt_store      = m_podioDataSvc->getCollections();
-
-  // Merge collections and readcollections into one
-  evt_store.insert(evt_store.end(), evt_store_read.begin(), evt_store_read.end());
-  // Remove possible duplicates
-  auto end = evt_store.end();
-  for (auto it = evt_store.begin(); it != end; ++it) {
-    end = std::remove(it + 1, end, *it);
-  }
-  evt_store.erase(end, evt_store.end());
 
   std::string fulltype = "";
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -936,7 +936,7 @@ void EDM4hep2LcioTool::FillMissingCollections(CollectionsPairVectors& collection
 void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::string& lcio_coll_name,
                                   lcio::LCEventImpl* lcio_event, CollectionsPairVectors& collection_pairs) {
   // Get the associated type to the collection name
-  auto evt_store      = m_podioDataSvc->getCollections();
+  auto evt_store = m_podioDataSvc->getCollections();
 
   std::string fulltype = "";
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -65,15 +65,8 @@ void Lcio2EDM4hepTool::convertRegister(const std::string& edm_name, const std::s
 
   // Check if collection was already registered
   auto collections      = m_podioDataSvc->getCollections();
-  auto read_collections = m_podioDataSvc->getReadCollections();
   bool is_registered    = false;
   for (auto& coll : collections) {
-    if (coll.first == edm_name) {
-      is_registered = true;
-      return;
-    }
-  }
-  for (auto& coll : read_collections) {
     if (coll.first == edm_name) {
       is_registered = true;
       return;

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -64,8 +64,8 @@ void Lcio2EDM4hepTool::convertRegister(const std::string& edm_name, const std::s
   wrapper->setData(mycoll);
 
   // Check if collection was already registered
-  auto collections      = m_podioDataSvc->getCollections();
-  bool is_registered    = false;
+  auto collections   = m_podioDataSvc->getCollections();
+  bool is_registered = false;
   for (auto& coll : collections) {
     if (coll.first == edm_name) {
       is_registered = true;


### PR DESCRIPTION
BEGINRELEASENOTES
- remove calls to `getReadCollections()` to comply with updated k4fwcore https://github.com/key4hep/k4FWCore/pull/70

ENDRELEASENOTES
