### PR TITLE
Warn if hits and contributions are not the same size for clusters

### DIFF
--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -77,3 +77,10 @@ gaudi_add_module(Lcio2EDM4hep
 target_include_directories(Lcio2EDM4hep PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
 )
+
+# Copy python parsing file to genConfDir in Gaudi
+add_custom_command(
+        TARGET MarlinWrapper POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_SOURCE_DIR}/k4MarlinWrapper/python/k4MarlinWrapper/parseConstants.py
+                ${CMAKE_CURRENT_BINARY_DIR}/genConfDir/k4MarlinWrapper/parseConstants.py)

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -497,6 +497,10 @@ void EDM4hep2LcioTool::convertClusters(vec_pair<lcio::ClusterImpl*, edm4hep::Clu
               lcio_cluster->addHit(nullptr, 0);
           }
         }
+      } else {
+        error() << "There must be the same number of hits and hit contributions to convert clusters and the associated "
+                   "Calorimeter Hits"
+                << endmsg;
       }
 
       // Add LCIO and EDM4hep pair collections to vec


### PR DESCRIPTION
BEGINRELEASENOTES
- Add error message if hits and hit contributions in clusters are not the same size
- Copy `parseConstants.py` file to Gaudi-generated genConfDir to make it available Gaudi-wide

ENDRELEASENOTES
