### PR TITLE
Handle k4lcioreader errors

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -35,8 +35,9 @@ private:
   bool collectionExist(const std::string& collection_name);
 
   template <typename T>
-  void convertRegister(const std::string& edm_name, const std::string& lcio_name, std::unique_ptr<k4LCIOConverter>& lcio_conver,
-                       const lcio::LCCollection* const lcio_coll, const bool cnv_metadata = false);
+  void convertRegister(const std::string& edm_name, const std::string& lcio_name,
+                       std::unique_ptr<k4LCIOConverter>& lcio_conver, const lcio::LCCollection* const lcio_coll,
+                       const bool cnv_metadata = false);
 };
 
 #endif

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -35,7 +35,7 @@ private:
   bool collectionExist(const std::string& collection_name);
 
   template <typename T>
-  void convertRegister(const std::string& edm_name, const std::string& lcio_name, k4LCIOConverter* lcio_conver,
+  void convertRegister(const std::string& edm_name, const std::string& lcio_name, std::unique_ptr<k4LCIOConverter>& lcio_conver,
                        const lcio::LCCollection* const lcio_coll, const bool cnv_metadata = false);
 };
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -40,8 +40,8 @@ StatusCode Lcio2EDM4hepTool::finalize() {
 // **********************************
 template <typename T>
 void Lcio2EDM4hepTool::convertRegister(const std::string& edm_name, const std::string& lcio_name,
-                                       std::unique_ptr<k4LCIOConverter>& lcio_converter, const lcio::LCCollection* const lcio_coll,
-                                       const bool cnv_metadata) {
+                                       std::unique_ptr<k4LCIOConverter>& lcio_converter,
+                                       const lcio::LCCollection* const lcio_coll, const bool cnv_metadata) {
   debug() << "Converting collection: " << lcio_name << " from LCIO to EDM4hep " << edm_name << endmsg;
 
   // Convert and get EDM4hep collection
@@ -123,8 +123,6 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
   return false;
 }
 
-
-
 // **********************************
 // - Convert all collections indicated in Tool parameters
 // - Some collections implicitly convert associated collections, as for
@@ -134,7 +132,7 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
 // **********************************
 StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   // Set the event to the converter
-  podio::CollectionIDTable* id_table = m_podioDataSvc->getCollectionIDs();
+  podio::CollectionIDTable*        id_table       = m_podioDataSvc->getCollectionIDs();
   std::unique_ptr<k4LCIOConverter> lcio_converter = std::make_unique<k4LCIOConverter>(id_table);
   lcio_converter->set(the_event);
 
@@ -166,7 +164,8 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
         lcio_coll          = the_event->getCollection(m_params[i]);
         lcio_coll_type_str = lcio_coll->getTypeName();
       } catch (const lcio::DataNotAvailableException& ex) {
-        warning() << "LCIO Collection " << m_params[i] << " not found in the event, skipping conversion to EDM4hep" << endmsg;
+        warning() << "LCIO Collection " << m_params[i] << " not found in the event, skipping conversion to EDM4hep"
+                  << endmsg;
         continue;
       }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Use unique_ptr instead of new for converter
- Improve comments and error messages
- Handle errors coming from k4LCIOReader conversion

ENDRELEASENOTES
