### PR TITLE
Install the examples into the share directory

### DIFF
--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -93,3 +93,6 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy
                 ${CMAKE_SOURCE_DIR}/k4MarlinWrapper/python/k4MarlinWrapper/parseConstants.py
                 ${CMAKE_CURRENT_BINARY_DIR}/genConfDir/k4MarlinWrapper/parseConstants.py)
+
+# Install the example options files to share to make them easily accessible
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/examples DESTINATION share)


### PR DESCRIPTION
BEGINRELEASENOTES
- Install the `examples/` directory into `<install-prefix>/share/` to make them more easily available after installation. In Key4hep releases they will be accessible via `$K4MARLINWRAPPER/examples/`.

ENDRELEASENOTES
