### PR TITLE
Overhaul python configuration of EDM conversion tools

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
@@ -118,4 +118,4 @@ The `event_display.py` options file that is used above and that is present in th
 - Exchange the LCIO input reading by the podio input reading (see above)
 - Attach the `EDM4hep2LcioTool` to the wrapped `CEDViewer` processor
 
-This should allow to arrive at a similar steering file even for slightly different configurations. One potential pitfal is the slightly different naming of the `ddsim` outputs between LCIO and EDM4hep (see [this issue](https://github.com/AIDASoft/DD4hep/issues/921)). This can be addressed by configuring the EDM4hep to LCIO converter (`edmConvTool` in the code above) to map the names accordingly.
+This should allow one to arrive at a similar steering file even for slightly different configurations. One potential pitfall is the slightly different naming of the `ddsim` outputs between LCIO and EDM4hep (see [this issue](https://github.com/AIDASoft/DD4hep/issues/921)). This can be addressed by configuring the EDM4hep to LCIO converter (`edmConvTool` in the code above) to map the names accordingly.

--- a/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
@@ -83,7 +83,8 @@ MyCEDViewer.Parameters = {
                           
 # EDM4hep to LCIO converter
 edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")
-edmConvTool.Parameters = ["*"]
+edmConvTool.convertAll = True
+edmConvTool.collNameMapping = {'MCParticles': 'MCParticle'}
 edmConvTool.OutputLevel = DEBUG
 MyCEDViewer.EDM4hep2LcioTool = edmConvTool
 
@@ -117,16 +118,4 @@ The `event_display.py` options file that is used above and that is present in th
 - Exchange the LCIO input reading by the podio input reading (see above)
 - Attach the `EDM4hep2LcioTool` to the wrapped `CEDViewer` processor
 
-This should allow to arrive at a similar steering file even for slightly different configurations. One potential pitfal is the slightly different naming of the `ddsim` outputs between LCIO and EDM4hep (see [this issue](https://github.com/AIDASoft/DD4hep/issues/921)). For the `event_display.py` in the `examples` drawing the `MCParticle`s in the event display required to change the name of the collection that is used in the `DrawInLayers` configuration parameter of the `CEDViewer`:
-
-```diff
-@@ -156,7 +156,7 @@ MyCEDViewer.Parameters = {
-                               "MarlinTrkTracks", "0", "6", "7",
-                               "PandoraClusters", "0", "3", "8",
-                               "PandoraPFOs", "0", "3", "9",
--                              "MCParticle", "0", "3", "0",
-+                              "MCParticles", "0", "3", "0",
-                               "VertexBarrelHits", "0", "5", "11",
-                               "VertexEndcapHits", "0", "5", "11",
-                               "InnerTrackerBarrelHits", "0", "5", "11",
-```
+This should allow to arrive at a similar steering file even for slightly different configurations. One potential pitfal is the slightly different naming of the `ddsim` outputs between LCIO and EDM4hep (see [this issue](https://github.com/AIDASoft/DD4hep/issues/921)). This can be addressed by configuring the EDM4hep to LCIO converter (`edmConvTool` in the code above) to map the names accordingly.

--- a/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
@@ -117,17 +117,18 @@ Note and review the following when using the converters:
 - If using the `PodioInput` to read events: collection names must be indicated both in the `PodioInput` and the `EDM4hep2LcioTool`.
 - Collections not indicated to be converted **will not** be converted even if its a dependency from an indicated collection to be converted.
 - If a converted collection is used later by a Gaudi Algorithm, and this Gaudi Algorithm indicates the use of that collection in the `Parameters`, the converted collection name must match the name indicated in the Gaudi Algorithm `Parameters`.
-  + For example: A collection may be converted with the following parameters: `ReconstructedParticles", "ReconstructedParticleLCIO"`
+  + For example: A collection may be converted with the following parameters: `"ReconstructedParticles": "ReconstructedParticleLCIO"`
   + A Gaudi Algorithm may indicate in their `Parameters`: `"PFOCollection": ["ReconstructedParticleLCIO"]`
 
 ###  EDM4hep to LCIO converter
 
 Collections from events that are already read, or are produced by a Gaudi Algorithm can be converted from EDM4hep to LCIO format:
 
-1. Instantiate the `EDM4hep2LcioTool` Gaudi Tool.
-2. Indicate the collections to convert in `Parameters`.
-  + To convert all available collections write an asterisk, like follows: `edmConvTool.Parameters = ["*"]`
-  + Arguments are read in groups of 2: name of the EDM4hep collection, name of the LCIO converted collection.
+1. Instantiate the `EDM4hep2LcioTool` Gaudi Tool, e.g. as `edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")`
+2. Indicate the collections to convert using the options of the tool.
+  + To sipmly convert all available collections use `edmConvTool.convertAll = True` (this is also the default!)
+  + If you want to convert all available collections but want to rename some of them, e.g. because an algorithm expects a different name, use the `collNameMapping` option. This maps the input name to the output name; `edmConvTool.collNameMapping = {'MCParticles': 'MCParticle'}` will convert the input `'MCParticles'` into the `'MCParticle'` collection.
+  + To convert only a subset of all available collections, set the `convertAll` option to `False` and indicate the collections to convert via the `collNameMapping` option.
 3. Select the Gaudi Algorithm that will convert the indicated collections.
 4. Add the Tool to the Gaudi Algorithm.
 
@@ -137,10 +138,11 @@ from Configurables import ToolSvc, EDM4hep2LcioTool
 # 1
 edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")
 # 2
-edmConvTool.Parameters = [
-    "EFlowTrack", "EFlowTrack_LCIO",
-    "ReconstructedParticles", "ReconstructedParticle_LCIO"
-]
+edmConvToll.convertAll = False
+edmConvTool.collNameMapping = {
+    "EFlowTrack": "EFlowTrack_LCIO",
+    "ReconstructedParticles": "ReconstructedParticle_LCIO"
+}
 edmConvTool.OutputLevel = DEBUG
 
 # 3
@@ -154,10 +156,11 @@ InitDD4hep.EDM4hep2LcioTool=edmConvTool
 
 Collections from events that are already read, or are produced by a gaudi Algorithm can be converted from LCIO to EDM4hep format:
 
-1. Instantiate the `Lcio2EDM4hepTool` Gaudi Tool.
-2. Indicate the collections to convert in `Parameters`.
-  + To convert all available collections write an asterisk, like follows: `lcioConvTool.Parameters = ["*"]`
-  + Arguments are read in groups of 2: name of the LCIO collection, name of the EDM4hep converted collection.
+1. Instantiate the `Lcio2EDM4hepTool` Gaudi Tool, e.g. as `lcioConvTool = Lcio2EDM4hepTool("LCIO2EDM4hep")`.
+2. Indicate the collections to convert in the options of the tool.
+  + To sipmly convert all available collections use `lcioConvTool.convertAll = True` (this is also the default!)
+  + If you want to convert all available collections but want to rename some of them, e.g. because an algorithm expects a different name, use the `collNameMapping` option. This maps the input name to the output name; `lcioConvTool.collNameMapping = {'MCParticles': 'MCParticle'}` will convert the input `'MCParticles'` into the `'MCParticle'` collection.
+  + To convert only a subset of all available collections, set the `convertAll` option to `False` and indicate the collections to convert via the `collNameMapping` option.
 3. Select the Gaudi Algorithm that will convert the indicated collections.
 4. Add the Tool to the Gaudi Algorithm.
 
@@ -167,12 +170,13 @@ from Configurables import ToolSvc, Lcio2EDM4hepTool
 # 1
 lcioConvTool = Lcio2EDM4hepTool("LCIO2EDM4hep")
 # 2
-lcioConvTool.Parameters = [
-    "EFlowTrackConv", "EFlowTrackEDM4hep",
-    "ReconstructedParticle", "ReconstructedParticlesEDM4hep",
-    "BuildUpVertices", "BuildUpVerticesEDM4hep",
-    "PrimaryVertices", "PrimaryVerticesEDM4hep"
-]
+lcioConvTool.convertAll = False
+lcioConvTool.collNameMapping = {
+    "EFlowTrackConv": "EFlowTrackEDM4hep",
+    "ReconstructedParticle": "ReconstructedParticlesEDM4hep",
+    "BuildUpVertices": "BuildUpVerticesEDM4hep",
+    "PrimaryVertices": "PrimaryVerticesEDM4hep"
+}
 lcioConvTool.OutputLevel = DEBUG
 
 # 3
@@ -181,5 +185,3 @@ JetClusteringAndRefiner = MarlinProcessorWrapper("JetClusteringAndRefiner")
 # 4
 JetClusteringAndRefiner.Lcio2EDM4hepTool=lcioConvTool
 ```
-
-

--- a/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
@@ -126,7 +126,7 @@ Collections from events that are already read, or are produced by a Gaudi Algori
 
 1. Instantiate the `EDM4hep2LcioTool` Gaudi Tool, e.g. as `edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")`
 2. Indicate the collections to convert using the options of the tool.
-  + To sipmly convert all available collections use `edmConvTool.convertAll = True` (this is also the default!)
+  + To simply convert all available collections use `edmConvTool.convertAll = True` (this is also the default!)
   + If you want to convert all available collections but want to rename some of them, e.g. because an algorithm expects a different name, use the `collNameMapping` option. This maps the input name to the output name; `edmConvTool.collNameMapping = {'MCParticles': 'MCParticle'}` will convert the input `'MCParticles'` into the `'MCParticle'` collection.
   + To convert only a subset of all available collections, set the `convertAll` option to `False` and indicate the collections to convert via the `collNameMapping` option.
 3. Select the Gaudi Algorithm that will convert the indicated collections.
@@ -158,7 +158,7 @@ Collections from events that are already read, or are produced by a gaudi Algori
 
 1. Instantiate the `Lcio2EDM4hepTool` Gaudi Tool, e.g. as `lcioConvTool = Lcio2EDM4hepTool("LCIO2EDM4hep")`.
 2. Indicate the collections to convert in the options of the tool.
-  + To sipmly convert all available collections use `lcioConvTool.convertAll = True` (this is also the default!)
+  + To simply convert all available collections use `lcioConvTool.convertAll = True` (this is also the default!)
   + If you want to convert all available collections but want to rename some of them, e.g. because an algorithm expects a different name, use the `collNameMapping` option. This maps the input name to the output name; `lcioConvTool.collNameMapping = {'MCParticles': 'MCParticle'}` will convert the input `'MCParticles'` into the `'MCParticle'` collection.
   + To convert only a subset of all available collections, set the `convertAll` option to `False` and indicate the collections to convert via the `collNameMapping` option.
 3. Select the Gaudi Algorithm that will convert the indicated collections.

--- a/k4MarlinWrapper/examples/event_display.py
+++ b/k4MarlinWrapper/examples/event_display.py
@@ -156,7 +156,7 @@ MyCEDViewer.Parameters = {
                               "MarlinTrkTracks", "0", "6", "7",
                               "PandoraClusters", "0", "3", "8",
                               "PandoraPFOs", "0", "3", "9",
-                              "MCParticles", "0", "3", "0",
+                              "MCParticle", "0", "3", "0",
                               "VertexBarrelHits", "0", "5", "11",
                               "VertexEndcapHits", "0", "5", "11",
                               "InnerTrackerBarrelHits", "0", "5", "11",
@@ -193,7 +193,8 @@ MyCEDViewer.Parameters = {
 
 # EDM4hep to LCIO converter
 edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")
-edmConvTool.Parameters = ["*"]
+edmConvTool.convertAll = True
+edmConvTool.collNameMapping = {'MCParticles': 'MCParticle'}
 edmConvTool.OutputLevel = DEBUG
 MyCEDViewer.EDM4hep2LcioTool = edmConvTool
 

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -1,14 +1,10 @@
 #ifndef K4MARLINWRAPPER_EDM4HEP2LCIO_H
 #define K4MARLINWRAPPER_EDM4HEP2LCIO_H
 
-// std
-#include <algorithm>
-#include <bitset>
-#include <string>
-#include <vector>
-
-// GAUDI
-#include <GaudiAlg/GaudiTool.h>
+// k4MarlinWrapper
+#include "k4MarlinWrapper/LCEventWrapper.h"
+#include "k4MarlinWrapper/converters/IEDMConverter.h"
+#include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
 
 // FWCore
 #include <k4FWCore/DataHandle.h>
@@ -16,10 +12,15 @@
 //k4EDM4hep2LcioConv
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h"
 
-// k4MarlinWrapper
-#include "k4MarlinWrapper/LCEventWrapper.h"
-#include "k4MarlinWrapper/converters/IEDMConverter.h"
-#include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
+// GAUDI
+#include <GaudiAlg/GaudiTool.h>
+
+// std
+#include <algorithm>
+#include <bitset>
+#include <map>
+#include <string>
+#include <vector>
 
 class EDM4hep2LcioTool : public GaudiTool, virtual public IEDMConverter {
 public:
@@ -31,7 +32,8 @@ public:
   StatusCode convertCollections(lcio::LCEventImpl* lcio_event);
 
 private:
-  Gaudi::Property<std::vector<std::string>> m_edm2lcio_params{this, "Parameters", {}};
+  Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};
+  Gaudi::Property<bool>                               m_convertAll{this, "convertAll", true};
 
   PodioDataSvc*                   m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -15,6 +15,9 @@
 // Converter Interface
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
+#include <map>
+#include <string>
+
 class Lcio2EDM4hepTool : public GaudiTool, virtual public IEDMConverter {
 public:
   Lcio2EDM4hepTool(const std::string& type, const std::string& name, const IInterface* parent);
@@ -25,7 +28,8 @@ public:
   StatusCode convertCollections(lcio::LCEventImpl* lcio_event);
 
 private:
-  Gaudi::Property<std::vector<std::string>> m_params{this, "Parameters", {}};
+  Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};
+  Gaudi::Property<bool>                               m_convertAll{this, "convertAll", true};
 
   std::map<std::string, DataObjectHandleBase*> m_dataHandlesMap;
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -273,11 +273,11 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
 StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   const auto collections = m_podioDataSvc->getCollections();
 
-  // Start of with the pre-defined collection name mappings
+  // Start off with the pre-defined collection name mappings
   auto collsToConvert{m_collNames.value()};
   if (m_convertAll) {
     info() << "Converting all collections from EDM4hep to LCIO" << endmsg;
-    // And simply add the rest, taking exploiting the fact that emplace will not
+    // And simply add the rest, exploiting the fact that emplace will not
     // replace existing entries with the same key
     for (const auto& [name, _] : collections) {
       collsToConvert.emplace(name, name);

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -134,7 +134,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   if (m_convertAll) {
     const auto* collections = the_event->getCollectionNames();
     for (const auto& collName : *collections) {
-      // And simply add the rest, taking exploiting the fact that emplace will not
+      // And simply add the rest, exploiting the fact that emplace will not
       // replace existing entries with the same key
       collsToConvert.emplace(collName, collName);
     }

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -129,7 +129,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   std::unique_ptr<k4LCIOConverter> lcio_converter = std::make_unique<k4LCIOConverter>(id_table);
   lcio_converter->set(the_event);
 
-  // Start of with the pre-defined collection name mappings
+  // Start off with the pre-defined collection name mappings
   auto collsToConvert{m_collNames.value()};
   if (m_convertAll) {
     const auto* collections = the_event->getCollectionNames();

--- a/test/gaudi_opts/clicRec_e4h_input.py
+++ b/test/gaudi_opts/clicRec_e4h_input.py
@@ -74,7 +74,7 @@ MyAIDAProcessor.Parameters = {
 
 # EDM4hep to LCIO converter
 edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")
-edmConvTool.Parameters = ["*"]
+edmConvTool.convertAll = True
 edmConvTool.OutputLevel = DEBUG
 MyAIDAProcessor.EDM4hep2LcioTool=edmConvTool
 
@@ -118,11 +118,12 @@ VXDBarrelDigitiser.Parameters = {
 
 # LCIO to EDM4hep
 VXDBarrelDigitiserLCIOConv = Lcio2EDM4hepTool("VXDBarrelDigitiserLCIOConv")
-VXDBarrelDigitiserLCIOConv.Parameters = [
+VXDBarrelDigitiserLCIOConv.convertAll = False
+VXDBarrelDigitiserLCIOConv.collNameMapping = {
   # This should be a TrackerHitPlane, but it gets treated as a TrackerHit
-  "VXDTrackerHits", "VXDTrackerHits",
-  "VXDTrackerHitRelations", "VXDTrackerHitRelations"
-  ]
+  "VXDTrackerHits": "VXDTrackerHits",
+  "VXDTrackerHitRelations": "VXDTrackerHitRelations"
+  }
 VXDBarrelDigitiserLCIOConv.OutputLevel = DEBUG
 # Add it to VXDBarrelDigitiser Algorithm
 VXDBarrelDigitiser.Lcio2EDM4hepTool=VXDBarrelDigitiserLCIOConv
@@ -144,11 +145,12 @@ VXDEndcapDigitiser.Parameters = {
 
 # LCIO to EDM4hep
 VXDEndcapDigitiserLCIOConv = Lcio2EDM4hepTool("VXDEndcapDigitiserLCIOConv")
-VXDEndcapDigitiserLCIOConv.Parameters = [
+VXDEndcapDigitiserLCIOConv.convertAll = False
+VXDEndcapDigitiserLCIOConv.collNameMapping = {
   # This should be a TrackerHitPlane, but it gets treated as a TrackerHit
-  "VXDEndcapTrackerHits", "VXDEndcapTrackerHits",
-  "VXDEndcapTrackerHitRelations", "VXDEndcapTrackerHitRelations"
-  ]
+  "VXDEndcapTrackerHits": "VXDEndcapTrackerHits",
+  "VXDEndcapTrackerHitRelations": "VXDEndcapTrackerHitRelations"
+  }
 VXDEndcapDigitiserLCIOConv.OutputLevel = DEBUG
 # Add it to VXDEndcapDigitiser Algorithm
 VXDEndcapDigitiser.Lcio2EDM4hepTool=VXDEndcapDigitiserLCIOConv
@@ -170,11 +172,12 @@ InnerPlanarDigiProcessor.Parameters = {
 
 # LCIO to EDM4hep
 InnerPlanarDigiProcessorLCIOConv = Lcio2EDM4hepTool("InnerPlanarDigiProcessorLCIOConv")
-InnerPlanarDigiProcessorLCIOConv.Parameters = [
+InnerPlanarDigiProcessorLCIOConv.convertAll = False
+InnerPlanarDigiProcessorLCIOConv.collNameMapping = {
   # This should be a TrackerHitPlane, but it gets treated as a TrackerHit
-  "ITrackerHits", "ITrackerHits",
-  "InnerTrackerBarrelHitsRelations", "InnerTrackerBarrelHitsRelations"
-  ]
+  "ITrackerHits": "ITrackerHits",
+  "InnerTrackerBarrelHitsRelations": "InnerTrackerBarrelHitsRelations"
+  }
 InnerPlanarDigiProcessorLCIOConv.OutputLevel = DEBUG
 # Add it to InnerPlanarDigiProcessor Algorithm
 InnerPlanarDigiProcessor.Lcio2EDM4hepTool=InnerPlanarDigiProcessorLCIOConv
@@ -196,11 +199,12 @@ InnerEndcapPlanarDigiProcessor.Parameters = {
                                              }
 # LCIO to EDM4hep
 InnerEndcapPlanarDigiProcessorLCIOConv = Lcio2EDM4hepTool("InnerEndcapPlanarDigiProcessorLCIOConv")
-InnerEndcapPlanarDigiProcessorLCIOConv.Parameters = [
+InnerEndcapPlanarDigiProcessorLCIOConv.convertAll = False
+InnerEndcapPlanarDigiProcessorLCIOConv.collNameMapping = {
   # This should be a TrackerHitPlane, but it gets treated as a TrackerHit
-  "ITrackerEndcapHits", "ITrackerEndcapHits",
-  "InnerTrackerEndcapHitsRelations", "InnerTrackerEndcapHitsRelations"
-  ]
+  "ITrackerEndcapHits": "ITrackerEndcapHits",
+  "InnerTrackerEndcapHitsRelations": "InnerTrackerEndcapHitsRelations"
+  }
 InnerEndcapPlanarDigiProcessorLCIOConv.OutputLevel = DEBUG
 # Add it to InnerEndcapPlanarDigiProcessor Algorithm
 InnerEndcapPlanarDigiProcessor.Lcio2EDM4hepTool=InnerEndcapPlanarDigiProcessorLCIOConv
@@ -223,11 +227,12 @@ OuterPlanarDigiProcessor.Parameters = {
                                        }
 # LCIO to EDM4hep
 OuterPlanarDigiProcessorLCIOConv = Lcio2EDM4hepTool("OuterPlanarDigiProcessorLCIOConv")
-OuterPlanarDigiProcessorLCIOConv.Parameters = [
+OuterPlanarDigiProcessorLCIOConv.convertAll = False
+OuterPlanarDigiProcessorLCIOConv.collNameMapping = {
   # This should be a TrackerHitPlane, but it gets treated as a TrackerHit
-  "OTrackerHits", "OTrackerHits",
-  "OuterTrackerBarrelHitsRelations", "OuterTrackerBarrelHitsRelations"
-  ]
+  "OTrackerHits": "OTrackerHits",
+  "OuterTrackerBarrelHitsRelations": "OuterTrackerBarrelHitsRelations"
+  }
 OuterPlanarDigiProcessorLCIOConv.OutputLevel = DEBUG
 # Add it to OuterPlanarDigiProcessor Algorithm
 OuterPlanarDigiProcessor.Lcio2EDM4hepTool=OuterPlanarDigiProcessorLCIOConv
@@ -249,11 +254,12 @@ OuterEndcapPlanarDigiProcessor.Parameters = {
                                              }
 # LCIO to EDM4hep
 OuterEndcapPlanarDigiProcessorLCIOConv = Lcio2EDM4hepTool("OuterEndcapPlanarDigiProcessorLCIOConv")
-OuterEndcapPlanarDigiProcessorLCIOConv.Parameters = [
+OuterEndcapPlanarDigiProcessorLCIOConv.convertAll = False
+OuterEndcapPlanarDigiProcessorLCIOConv.collNameMapping = {
   # This should be a TrackerHitPlane, but it gets treated as a TrackerHit
-  "OTrackerEndcapHits", "OTrackerEndcapHits",
-  "OuterTrackerEndcapHitsRelations", "OuterTrackerEndcapHitsRelations"
-  ]
+  "OTrackerEndcapHits": "OTrackerEndcapHits",
+  "OuterTrackerEndcapHitsRelations": "OuterTrackerEndcapHitsRelations"
+  }
 OuterEndcapPlanarDigiProcessorLCIOConv.OutputLevel = DEBUG
 # Add it to OuterEndcapPlanarDigiProcessor Algorithm
 OuterEndcapPlanarDigiProcessor.Lcio2EDM4hepTool=OuterEndcapPlanarDigiProcessorLCIOConv
@@ -297,11 +303,12 @@ MyConformalTracking.Parameters = {
                                   }
 # LCIO to EDM4hep
 MyConformalTrackingLCIOConv = Lcio2EDM4hepTool("MyConformalTrackingLCIOConv")
-MyConformalTrackingLCIOConv.Parameters = [
+MyConformalTrackingLCIOConv.convertAll = False
+MyConformalTrackingLCIOConv.collNameMapping = {
   # This should be a TrackerHitPlane, but it gets treated as a TrackerHit
-  "DebugHits", "DebugHits",
-  "SiTracksCT", "SiTracksCT",
-  ]
+  "DebugHits": "DebugHits",
+  "SiTracksCT": "SiTracksCT",
+  }
 MyConformalTrackingLCIOConv.OutputLevel = DEBUG
 # Add it to MyConformalTracking Algorithm
 MyConformalTracking.Lcio2EDM4hepTool=MyConformalTrackingLCIOConv
@@ -327,9 +334,10 @@ ClonesAndSplitTracksFinder.Parameters = {
                                          }
 # LCIO to EDM4hep
 ClonesAndSplitTracksFinderLCIOConv = Lcio2EDM4hepTool("ClonesAndSplitTracksFinderLCIOConv")
-ClonesAndSplitTracksFinderLCIOConv.Parameters = [
-  "SiTracks", "SiTracks"
-  ]
+ClonesAndSplitTracksFinderLCIOConv.convertAll = False
+ClonesAndSplitTracksFinderLCIOConv.collNameMapping = {
+  "SiTracks": "SiTracks"
+  }
 ClonesAndSplitTracksFinderLCIOConv.OutputLevel = DEBUG
 # Add it to ClonesAndSplitTracksFinder Algorithm
 ClonesAndSplitTracksFinder.Lcio2EDM4hepTool=ClonesAndSplitTracksFinderLCIOConv
@@ -354,9 +362,10 @@ Refit.Parameters = {
                     }
 # LCIO to EDM4hep
 RefitLCIOConv = Lcio2EDM4hepTool("Refit")
-RefitLCIOConv.Parameters = [
-  "SiTracks_Refitted", "SiTracks_Refitted"
-  ]
+RefitLCIOConv.convertAll = False
+RefitLCIOConv.collNameMapping = {
+  "SiTracks_Refitted": "SiTracks_Refitted"
+  }
 RefitLCIOConv.OutputLevel = DEBUG
 # Add it to RefitLCIOConv Algorithm
 Refit.Lcio2EDM4hepTool=RefitLCIOConv
@@ -383,9 +392,10 @@ MyClicEfficiencyCalculator.Parameters = {
                                          }
 # LCIO to EDM4hep
 MyClicEfficiencyCalculatorLCIOConv = Lcio2EDM4hepTool("MyClicEfficiencyCalculator")
-MyClicEfficiencyCalculatorLCIOConv.Parameters = [
-  "MCParticleNotReco", "MCParticleNotReco"
-  ]
+MyClicEfficiencyCalculatorLCIOConv.convertAll = False
+MyClicEfficiencyCalculatorLCIOConv.collNameMapping = {
+  "MCParticleNotReco": "MCParticleNotReco"
+  }
 MyClicEfficiencyCalculatorLCIOConv.OutputLevel = DEBUG
 # Add it to MyClicEfficiencyCalculatorLCIOConv Algorithm
 MyClicEfficiencyCalculator.Lcio2EDM4hepTool=MyClicEfficiencyCalculatorLCIOConv
@@ -503,15 +513,16 @@ MyDDCaloDigi.Parameters = {
                            }
 # LCIO to EDM4hep
 MyDDCaloDigiLCIOConv = Lcio2EDM4hepTool("MyDDCaloDigiLCIOConv")
-MyDDCaloDigiLCIOConv.Parameters = [
-  "ECALBarrel", "ECALBarrel",
-  "ECALEndcap", "ECALEndcap",
-  "ECALOther", "ECALOther",
-  "HCALBarrel", "HCALBarrel",
-  "HCALEndcap", "HCALEndcap",
-  "HCALOther", "HCALOther",
-  "RelationCaloHit", "RelationCaloHit"
-  ]
+MyDDCaloDigiLCIOConv.convertAll = False
+MyDDCaloDigiLCIOConv.collNameMapping = {
+  "ECALBarrel": "ECALBarrel",
+  "ECALEndcap": "ECALEndcap",
+  "ECALOther": "ECALOther",
+  "HCALBarrel": "HCALBarrel",
+  "HCALEndcap": "HCALEndcap",
+  "HCALOther": "HCALOther",
+  "RelationCaloHit": "RelationCaloHit"
+  }
 MyDDCaloDigiLCIOConv.OutputLevel = DEBUG
 # Add it to MyDDCaloDigi Algorithm
 MyDDCaloDigi.Lcio2EDM4hepTool=MyDDCaloDigiLCIOConv
@@ -622,11 +633,12 @@ MyDDMarlinPandora.Parameters = {
                                 }
 # LCIO to EDM4hep
 MyDDMarlinPandoraLCIOConv = Lcio2EDM4hepTool("MyDDMarlinPandoraLCIOConv")
-MyDDMarlinPandoraLCIOConv.Parameters = [
-  "PandoraClusters", "PandoraClusters",
-  "PandoraPFOs", "PandoraPFOs",
-  "PandoraStartVertices", "PandoraStartVertices",
-  ]
+MyDDMarlinPandoraLCIOConv.convertAll = False
+MyDDMarlinPandoraLCIOConv.collNameMapping = {
+  "PandoraClusters": "PandoraClusters",
+  "PandoraPFOs": "PandoraPFOs",
+  "PandoraStartVertices": "PandoraStartVertices",
+  }
 MyDDMarlinPandoraLCIOConv.OutputLevel = DEBUG
 # Add it to MyDDMarlinPandora Algorithm
 MyDDMarlinPandora.Lcio2EDM4hepTool=MyDDMarlinPandoraLCIOConv
@@ -647,10 +659,11 @@ MyDDSimpleMuonDigi.Parameters = {
                                  }
 # LCIO to EDM4hep
 MyDDSimpleMuonDigiLCIOConv = Lcio2EDM4hepTool("MyDDSimpleMuonDigiLCIOConv")
-MyDDSimpleMuonDigiLCIOConv.Parameters = [
-  "MUON", "MUON",
-  "RelationMuonHit", "RelationMuonHit"
-  ]
+MyDDSimpleMuonDigiLCIOConv.convertAll = False
+MyDDSimpleMuonDigiLCIOConv.collNameMapping = {
+  "MUON": "MUON",
+  "RelationMuonHit": "RelationMuonHit"
+  }
 MyDDSimpleMuonDigiLCIOConv.OutputLevel = DEBUG
 # Add it to MyDDSimpleMuonDigi Algorithm
 MyDDSimpleMuonDigi.Lcio2EDM4hepTool=MyDDSimpleMuonDigiLCIOConv
@@ -690,13 +703,14 @@ MyRecoMCTruthLinker.Parameters = {
                                   }
 # LCIO to EDM4hep
 MyRecoMCTruthLinkerLCIOConv = Lcio2EDM4hepTool("MyRecoMCTruthLinkerLCIOConv")
-MyRecoMCTruthLinkerLCIOConv.Parameters = [
-  "CalohitMCTruthLink", "CalohitMCTruthLink",
-  "ClusterMCTruthLink", "ClusterMCTruthLink",
-  "MCParticlesSkimmed", "MCParticlesSkimmed",
-  "RecoMCTruthLink", "RecoMCTruthLink",
-  "SiTracksMCTruthLink", "SiTracksMCTruthLink"
-  ]
+MyRecoMCTruthLinkerLCIOConv.convertAll = False
+MyRecoMCTruthLinkerLCIOConv.collNameMapping = {
+  "CalohitMCTruthLink": "CalohitMCTruthLink",
+  "ClusterMCTruthLink": "ClusterMCTruthLink",
+  "MCParticlesSkimmed": "MCParticlesSkimmed",
+  "RecoMCTruthLink": "RecoMCTruthLink",
+  "SiTracksMCTruthLink": "SiTracksMCTruthLink"
+  }
 MyRecoMCTruthLinkerLCIOConv.OutputLevel = DEBUG
 # Add it to MyRecoMCTruthLinker Algorithm
 MyRecoMCTruthLinker.Lcio2EDM4hepTool=MyRecoMCTruthLinkerLCIOConv
@@ -777,11 +791,12 @@ LumiCalReco.Parameters = {
                           }
 # LCIO to EDM4hep
 LumiCalRecoLCIOConv = Lcio2EDM4hepTool("LumiCalRecoLCIOConv")
-LumiCalRecoLCIOConv.Parameters = [
-  "LumiCal_Hits", "LumiCal_Hits",
-  "LumiCalClusters", "LumiCalClusters",
-  "LumiCalRecoParticles", "LumiCalRecoParticles"
-  ]
+LumiCalRecoLCIOConv.convertAll = False
+LumiCalRecoLCIOConv.collNameMapping = {
+  "LumiCal_Hits": "LumiCal_Hits",
+  "LumiCalClusters": "LumiCalClusters",
+  "LumiCalRecoParticles": "LumiCalRecoParticles"
+  }
 LumiCalRecoLCIOConv.OutputLevel = DEBUG
 # Add it to LumiCalReco Algorithm
 LumiCalReco.Lcio2EDM4hepTool=LumiCalRecoLCIOConv
@@ -800,9 +815,10 @@ RenameCollection.Parameters = {
                                }
 # LCIO to EDM4hep
 RenameCollectionLCIOConv = Lcio2EDM4hepTool("RenameCollectionLCIOConv")
-RenameCollectionLCIOConv.Parameters = [
-  "PFOsFromJets", "PFOsFromJets",
-  ]
+RenameCollectionLCIOConv.convertAll = False
+RenameCollectionLCIOConv.collNameMapping = {
+  "PFOsFromJets": "PFOsFromJets",
+  }
 RenameCollectionLCIOConv.OutputLevel = DEBUG
 # Add it to RenameCollection Algorithm
 RenameCollection.Lcio2EDM4hepTool=RenameCollectionLCIOConv
@@ -885,11 +901,12 @@ JetClusteringAndRefiner.Parameters = {
                                       }
 # LCIO to EDM4hep
 JetClusteringAndRefinerLCIOConv = Lcio2EDM4hepTool("JetClusteringAndRefinerLCIOConv")
-JetClusteringAndRefinerLCIOConv.Parameters = [
-  "VertexJets", "VertexJets",
-  "RefinedVertexJets", "RefinedVertexJets",
-  "RefinedVertices", "RefinedVertices"
-  ]
+JetClusteringAndRefinerLCIOConv.convertAll = False
+JetClusteringAndRefinerLCIOConv.collNameMapping = {
+  "VertexJets": "VertexJets",
+  "RefinedVertexJets": "RefinedVertexJets",
+  "RefinedVertices": "RefinedVertices"
+  }
 JetClusteringAndRefinerLCIOConv.OutputLevel = DEBUG
 # Add it to JetClusteringAndRefiner Algorithm
 JetClusteringAndRefiner.Lcio2EDM4hepTool=JetClusteringAndRefinerLCIOConv
@@ -940,9 +957,10 @@ OverlayFalse.Parameters = {
                            }
 # LCIO to EDM4hep
 OverlayFalseLCIOConv = Lcio2EDM4hepTool("OverlayFalseLCIOConv")
-OverlayFalseLCIOConv.Parameters = [
-  "MCPhysicsParticles", "MCPhysicsParticles"
-  ]
+OverlayFalseLCIOConv.convertAll = False
+OverlayFalseLCIOConv.collNameMapping = {
+  "MCPhysicsParticles": "MCPhysicsParticles"
+  }
 OverlayFalseLCIOConv.OutputLevel = DEBUG
 # Add it to OverlayFalse Algorithm
 OverlayFalse.Lcio2EDM4hepTool=OverlayFalseLCIOConv
@@ -1149,9 +1167,10 @@ MergeRP.Parameters = {
                       }
 # LCIO to EDM4hep
 MergeRPLCIOConv = Lcio2EDM4hepTool("MergeRPLCIOConv")
-MergeRPLCIOConv.Parameters = [
-  "MergedRecoParticles", "MergedRecoParticles"
-  ]
+MergeRPLCIOConv.convertAll = False
+MergeRPLCIOConv.collNameMapping = {
+  "MergedRecoParticles": "MergedRecoParticles"
+  }
 MergeRPLCIOConv.OutputLevel = DEBUG
 # Add it to MergeRP Algorithm
 MergeRP.Lcio2EDM4hepTool=MergeRPLCIOConv
@@ -1170,9 +1189,10 @@ MergeClusters.Parameters = {
                             }
 # LCIO to EDM4hep
 MergeClustersLCIOConv = Lcio2EDM4hepTool("MergeClustersLCIOConv")
-MergeClustersLCIOConv.Parameters = [
-  "MergedClusters", "MergedClusters"
-  ]
+MergeClustersLCIOConv.convertAll = False
+MergeClustersLCIOConv.collNameMapping = {
+  "MergedClusters": "MergedClusters"
+  }
 MergeClustersLCIOConv.OutputLevel = DEBUG
 # Add it to MergeClusters Algorithm
 MergeClusters.Lcio2EDM4hepTool=MergeClustersLCIOConv
@@ -1292,9 +1312,10 @@ CLICPfoSelectorDefault_HE.Parameters = {
                                         }
 # LCIO to EDM4hep
 CLICPfoSelectorDefault_HELCIOConv = Lcio2EDM4hepTool("CLICPfoSelectorDefault_HELCIOConv")
-CLICPfoSelectorDefault_HELCIOConv.Parameters = [
-  "SelectedPandoraPFOs", "SelectedPandoraPFOs"
-  ]
+CLICPfoSelectorDefault_HELCIOConv.convertAll = False
+CLICPfoSelectorDefault_HELCIOConv.collNameMapping = {
+  "SelectedPandoraPFOs": "SelectedPandoraPFOs"
+  }
 CLICPfoSelectorDefault_HELCIOConv.OutputLevel = DEBUG
 # Add it to CLICPfoSelectorDefault_HE Algorithm
 CLICPfoSelectorDefault_HE.Lcio2EDM4hepTool=CLICPfoSelectorDefault_HELCIOConv
@@ -1356,9 +1377,10 @@ CLICPfoSelectorLoose_HE.Parameters = {
                                       }
 # LCIO to EDM4hep
 CLICPfoSelectorLoose_HELCIOConv = Lcio2EDM4hepTool("CLICPfoSelectorLoose_HELCIOConv")
-CLICPfoSelectorLoose_HELCIOConv.Parameters = [
-  "CLICPfoSelectorLoose_HE", "CLICPfoSelectorLoose_HE"
-  ]
+CLICPfoSelectorLoose_HELCIOConv.convertAll = False
+CLICPfoSelectorLoose_HELCIOConv.collNameMapping = {
+  "CLICPfoSelectorLoose_HE": "CLICPfoSelectorLoose_HE"
+  }
 CLICPfoSelectorLoose_HELCIOConv.OutputLevel = DEBUG
 # Add it to CLICPfoSelectorLoose_HE Algorithm
 CLICPfoSelectorLoose_HE.Lcio2EDM4hepTool=CLICPfoSelectorLoose_HELCIOConv
@@ -1417,9 +1439,10 @@ CLICPfoSelectorTight_HE.Parameters = {
                                       }
 # LCIO to EDM4hep
 CLICPfoSelectorTight_HELCIOConv = Lcio2EDM4hepTool("CLICPfoSelectorTight_HELCIOConv")
-CLICPfoSelectorTight_HELCIOConv.Parameters = [
-  "TightSelectedPandoraPFOs", "TightSelectedPandoraPFOs"
-  ]
+CLICPfoSelectorTight_HELCIOConv.convertAll = False
+CLICPfoSelectorTight_HELCIOConv.collNameMapping = {
+  "TightSelectedPandoraPFOs": "TightSelectedPandoraPFOs"
+  }
 CLICPfoSelectorTight_HELCIOConv.OutputLevel = DEBUG
 # Add it to CLICPfoSelectorTight_HE Algorithm
 CLICPfoSelectorTight_HE.Lcio2EDM4hepTool=CLICPfoSelectorTight_HELCIOConv
@@ -1479,9 +1502,10 @@ CLICPfoSelectorDefault_LE.Parameters = {
                                         }
 # LCIO to EDM4hep
 CLICPfoSelectorDefault_LELCIOConv = Lcio2EDM4hepTool("CLICPfoSelectorDefault_LELCIOConv")
-CLICPfoSelectorDefault_LELCIOConv.Parameters = [
-  "LE_SelectedPandoraPFOs", "LE_SelectedPandoraPFOs"
-  ]
+CLICPfoSelectorDefault_LELCIOConv.convertAll = False
+CLICPfoSelectorDefault_LELCIOConv.collNameMapping = {
+  "LE_SelectedPandoraPFOs": "LE_SelectedPandoraPFOs"
+  }
 CLICPfoSelectorDefault_LELCIOConv.OutputLevel = DEBUG
 # Add it to CLICPfoSelectorDefault_LE Algorithm
 CLICPfoSelectorDefault_LE.Lcio2EDM4hepTool=CLICPfoSelectorDefault_LELCIOConv
@@ -1542,9 +1566,10 @@ CLICPfoSelectorLoose_LE.Parameters = {
                                       }
 # LCIO to EDM4hep
 CLICPfoSelectorLoose_LELCIOConv = Lcio2EDM4hepTool("CLICPfoSelectorLoose_LELCIOConv")
-CLICPfoSelectorLoose_LELCIOConv.Parameters = [
-  "LE_LooseSelectedPandoraPFOs", "LE_LooseSelectedPandoraPFOs"
-  ]
+CLICPfoSelectorLoose_LELCIOConv.convertAll = False
+CLICPfoSelectorLoose_LELCIOConv.collNameMapping = {
+  "LE_LooseSelectedPandoraPFOs": "LE_LooseSelectedPandoraPFOs"
+  }
 CLICPfoSelectorLoose_LELCIOConv.OutputLevel = DEBUG
 # Add it to CLICPfoSelectorLoose_LE Algorithm
 CLICPfoSelectorLoose_LE.Lcio2EDM4hepTool=CLICPfoSelectorLoose_LELCIOConv
@@ -1605,9 +1630,10 @@ CLICPfoSelectorTight_LE.Parameters = {
                                       }
 # LCIO to EDM4hep
 CLICPfoSelectorTight_LELCIOConv = Lcio2EDM4hepTool("CLICPfoSelectorTight_LELCIOConv")
-CLICPfoSelectorTight_LELCIOConv.Parameters = [
-  "LE_TightSelectedPandoraPFOs", "LE_TightSelectedPandoraPFOs"
-  ]
+CLICPfoSelectorTight_LELCIOConv.convertAll = False
+CLICPfoSelectorTight_LELCIOConv.collNameMapping = {
+  "LE_TightSelectedPandoraPFOs": "LE_TightSelectedPandoraPFOs"
+  }
 CLICPfoSelectorTight_LELCIOConv.OutputLevel = DEBUG
 # Add it to CLICPfoSelectorTight_LE Algorithm
 CLICPfoSelectorTight_LE.Lcio2EDM4hepTool=CLICPfoSelectorTight_LELCIOConv
@@ -1670,11 +1696,12 @@ VertexFinder.Parameters = {
                            }
 # LCIO to EDM4hep
 VertexFinderLCIOConv = Lcio2EDM4hepTool("VertexFinderLCIOConv")
-VertexFinderLCIOConv.Parameters = [
-  "BuildUpVertices_V0", "BuildUpVertices_V0",
-  "BuildUpVertices", "BuildUpVertices",
-  "PrimaryVertices", "PrimaryVertices",
-  ]
+VertexFinderLCIOConv.convertAll = False
+VertexFinderLCIOConv.collNameMapping = {
+  "BuildUpVertices_V0": "BuildUpVertices_V0",
+  "BuildUpVertices": "BuildUpVertices",
+  "PrimaryVertices": "PrimaryVertices",
+  }
 VertexFinderLCIOConv.OutputLevel = DEBUG
 # Add it to VertexFinder Algorithm
 VertexFinder.Lcio2EDM4hepTool=VertexFinderLCIOConv

--- a/test/gaudi_opts/edm_converters.py
+++ b/test/gaudi_opts/edm_converters.py
@@ -10,27 +10,29 @@ evtsvc = k4DataSvc('EventDataSvc')
 
 # EDM4hep2lcio Tool
 edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")
-edmConvTool.Parameters = [
-    "E4H_CaloHitCollection", "LCIO_CaloHitCollection",
-    "E4H_RawCaloHitCollection", "LCIO_RawCaloHitCollection",
-    "E4H_TPCHitCollection", "LCIO_TPCHitCollection",
-    "E4H_TrackCollection", "LCIO_TrackCollection",
-    "E4H_SimTrackerHitCollection", "LCIO_SimTrackerHitCollection",
-    "E4H_TrackerHitCollection", "LCIO_TrackerHitCollection",
-    "E4H_MCParticleCollection", "LCIO_MCParticleCollection",
-    "E4H_SimCaloHitCollection", "LCIO_SimCaloHitCollection"
-]
+edmConvTool.convertAll = False
+edmConvTool.collNameMapping = {
+    "E4H_CaloHitCollection": "LCIO_CaloHitCollection",
+    "E4H_RawCaloHitCollection": "LCIO_RawCaloHitCollection",
+    "E4H_TPCHitCollection": "LCIO_TPCHitCollection",
+    "E4H_TrackCollection": "LCIO_TrackCollection",
+    "E4H_SimTrackerHitCollection": "LCIO_SimTrackerHitCollection",
+    "E4H_TrackerHitCollection": "LCIO_TrackerHitCollection",
+    "E4H_MCParticleCollection": "LCIO_MCParticleCollection",
+    "E4H_SimCaloHitCollection": "LCIO_SimCaloHitCollection"
+}
 
 # LCIO2EDM4hep Tool
 lcioConvTool = Lcio2EDM4hepTool("Lcio2EDM4hep")
-lcioConvTool.Parameters = [
-    "LCIO_CaloHitCollection", "E4H_CaloHitCollection_conv",
-    # "LCIO_TrackerHitCollection", "E4H_TrackerHitCollection_conv",
-    "LCIO_SimTrackerHitCollection", "E4H_SimTrackerHitCollection_conv",
-    "LCIO_TrackCollection", "E4H_TrackCollection_conv",
-    "LCIO_MCParticleCollection", "E4H_MCParticleCollection_conv",
-    "LCIO_SimCaloHitCollection", "E4H_SimCaloHitCollection_conv"
-]
+lcioConvTool.convertAll = False
+lcioConvTool.collNameMapping = {
+    "LCIO_CaloHitCollection": "E4H_CaloHitCollection_conv",
+    # "LCIO_TrackerHitCollection": "E4H_TrackerHitCollection_conv",
+    "LCIO_SimTrackerHitCollection": "E4H_SimTrackerHitCollection_conv",
+    "LCIO_TrackCollection": "E4H_TrackCollection_conv",
+    "LCIO_MCParticleCollection": "E4H_MCParticleCollection_conv",
+    "LCIO_SimCaloHitCollection": "E4H_SimCaloHitCollection_conv"
+}
 
 TestConversion = TestE4H2L("TestConversion")
 TestConversion.EDM4hep2LcioTool=edmConvTool


### PR DESCRIPTION
BEGINRELEASENOTES
-  EDM4hep2LcioTool, Lcio2EDM4hepTool: Breaking Change! Replaced configuration via a list of string (pairs) with a `convertAll` flag and a `collNameMapping` (map of string to string). This makes it possible to more easily convert all collections, but still override the naming of the target collection without having to type out all possible collections.

ENDRELEASENOTES

The main reason for implementing this is that it would allow for a rather easy solution of AIDASoft/DD4hep#921, because consistency between existing Marlin processors and ddsim with EDM4hep output could be established on the fly during the conversion (without having to know up front which collections will be there).

- [x] convert all examples and tests
- [x] update all documentation

Fixes AIDASoft/DD4hep#921