### PR TITLE
Make `isFirstEvent` work as expected in wrapped processors

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
@@ -12,6 +12,7 @@
 - Writing EDM4hep events with `PodioOutput()`
 - Writing EDM4hep events with `MarlinProcessorWrapper` of type `LCIOOutputProcessor`
 - Running non-thread algorithms/processors in parallel
+- Running wrapped Marlin processors that make use of the `isFirstEvent` method in their `processEvent` method to do some setup only in the first event. There is no way to make this thread safe. If you want your processor to be usable on in a multi threaded environment, you have to move this setup to `init`.
 
 ## Running Gaudi with multithreading support
 

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -249,7 +249,10 @@ StatusCode MarlinProcessorWrapper::execute() {
     } else {
       m_processor->processEvent(the_event);
     }
+
+    m_processor->setFirstEvent(false, marlin::ExternalProcessorMgrAccessor{this});
   }
+
   // Handle exceptions that may come from Marlin
   catch (marlin::SkipEventException& e) {
     // Store flag to prevent the rest of the event from processing


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix an issue where `isFirstEvent` always returns `false` in wrapped processors by calling `setFirstEvent` after processing the first event.

ENDRELEASENOTES

This was discovered by Jenny and if not fixed, would mean that processors relying on this would need quite a bit of work, see e.g. https://github.com/iLCSoft/MarlinKinfitProcessors/pull/19

- [x] Needs iLCSoft/Marlin#47