### PR TITLE
Fix leaking LCEvent every loop

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/LCEventWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/LCEventWrapper.h
@@ -28,23 +28,18 @@
 
 #include <GaudiKernel/DataObject.h>
 
+#include <memory>
+
 class LCEventWrapper : public DataObject {
 public:
-  // Set delete_event to true when manually creating the LCEvent
-  LCEventWrapper(EVENT::LCEvent* theEvent, bool delete_event = false)
-      : m_event(theEvent), m_delete_event(delete_event) {}
+  LCEventWrapper(std::unique_ptr<EVENT::LCEvent>&& theEvent) : m_event(std::move(theEvent)) {}
 
-  ~LCEventWrapper() {
-    if (m_delete_event) {
-      delete m_event;
-    }
-  };
+  ~LCEventWrapper() = default;
 
-  EVENT::LCEvent* getEvent() const { return m_event; }
+  EVENT::LCEvent* getEvent() const { return m_event.get(); }
 
 private:
-  EVENT::LCEvent* m_event        = nullptr;
-  bool            m_delete_event = false;
+  std::unique_ptr<EVENT::LCEvent> m_event{nullptr};
 };
 
 // Event Status Data Object to indicate if there was underlying LCEvent

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -62,7 +62,7 @@ StatusCode LcioEvent::execute() {
     // wrappers
     info() << "Reading from file: " << m_fileNames[0] << endmsg;
 
-    auto             myEvWr = new LCEventWrapper(theEvent.release());
+    auto             myEvWr = new LCEventWrapper(std::move(theEvent));
     const StatusCode sc     = eventSvc()->registerObject("/Event/LCEvent", myEvWr);
     if (sc.isFailure()) {
       error() << "Failed to store the LCEvent" << endmsg;

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "k4MarlinWrapper/MarlinProcessorWrapper.h"
+#include "IMPL/LCEventImpl.h"
 
 DECLARE_COMPONENT(MarlinProcessorWrapper)
 
@@ -209,9 +210,9 @@ StatusCode MarlinProcessorWrapper::execute() {
 
   if (sc.isFailure()) {
     // Register empty event
-    the_event = new lcio::LCEventImpl();
     debug() << "Registering empty Event for EDM4hep to LCIO conversion event in TES" << endmsg;
-    auto       pO     = std::make_unique<LCEventWrapper>(the_event, true);
+    auto pO           = std::make_unique<LCEventWrapper>(std::make_unique<lcio::LCEventImpl>());
+    the_event         = static_cast<IMPL::LCEventImpl*>(pO->getEvent());
     StatusCode reg_sc = evtSvc()->registerObject("/Event/LCEvent", pO.release());
     if (reg_sc.isFailure()) {
       error() << "Failed to register empty LCIO Event" << endmsg;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix memory leak in `LcioEvent`, where the event read from file was leaked every event.

ENDRELEASENOTES