### PR TITLE
EDM4hep2LCIO: fix call to FillMissingCollections

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -291,11 +291,9 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
     } else {
       debug() << " Collection " << lcioName << " already in place, skipping conversion. " << endmsg;
     }
-
-    if (!m_convertAll) {
-      FillMissingCollections(collection_pairs);
-    }
   }
+
+  FillMissingCollections(collection_pairs);
 
   return StatusCode::SUCCESS;
 }


### PR DESCRIPTION
We have to run some conversions in specific order, or make sure that links are correctly set. This also needs a fix in k4EDM4hep2LcioConv to correctly assign the SimCaloHitContributions


BEGINRELEASENOTES
- EDM4hep2LCIO: Fix so that FillMissingCollections is always called after other collections were converted. Needed also to correctly assign SimCalorimeterHitContributions. Depends on key4hep/k4EDM4hep2LcioConv#7, fixes #98

ENDRELEASENOTES
