### PR TITLE
Install the `examples` to the correct place for key4hep-stack installations

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -6,8 +6,8 @@ jobs:
   clang-format:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
     - name: Start container
       run: |
         docker run \

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   clang-format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -9,7 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         SETUP: ['/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
-        PAGE: ['doc/starterkit/k4MarlinWrapperCLIC/Readme', ]
+        PAGE: ['doc/starterkit/k4MarlinWrapperCLIC/Readme',
+               'doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper']
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -21,14 +22,16 @@ jobs:
         docker exec CI_container /bin/bash -c ' cd Package;/
         source ${{ matrix.SETUP }};\
         mkdir build; cd build;\
-        cmake .. -GNinja;\
-        ninja;\
+        cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=../install;\
+        ninja install;\
         '
     - name: CheckPage  
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;
         source ${{ matrix.SETUP }};
-        source build/k4marlinwrapperenv.sh;
+        export LD_LIBRARY_PATH=/Package/install/lib64:$LD_LIBRARY_PATH
+        export PYTHONPATH=/Package/install/python:$PYTHONPATH
+        export K4MARLINWRAPPER=/Package/install/share/k4MarlinWrapper
         mkdir testdir;
         cat .github/scripts/yamlheader.md  ${{ matrix.PAGE }}.md > testdir/test.md;
         cd testdir;

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -21,8 +21,8 @@ jobs:
         docker exec CI_container /bin/bash -c ' cd Package;/
         source ${{ matrix.SETUP }};\
         mkdir build; cd build;\
-        cmake .. ;\
-        make -j 2;\
+        cmake .. -GNinja;\
+        ninja;\
         '
     - name: CheckPage  
       run: |

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -11,8 +11,8 @@ jobs:
         SETUP: ['/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
         PAGE: ['doc/starterkit/k4MarlinWrapperCLIC/Readme', ]
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
     - name: Start container
       run: |
         docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         SETUP: ['/cvmfs/sw.hsf.org/key4hep/setup.sh', '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
     - name: Start container
       run: |
         docker run \

--- a/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
@@ -20,7 +20,7 @@ All the following steps assume that the environment is setup like above and that
 
 To create an input file for the event display we run a simple detector simulation using `ddsim` and a particle gun that shoots photons. The input file that we create here for illustration purposes has only 10 events, which also means that the creation should only take a few minutes. The steps to create this file are the following 
 
-```
+```bash
 ddsim --steeringFile CLICPerformance/clicConfig/clic_steer.py \
       --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
       --enableGun \

--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -95,4 +95,4 @@ add_custom_command(
                 ${CMAKE_CURRENT_BINARY_DIR}/genConfDir/k4MarlinWrapper/parseConstants.py)
 
 # Install the example options files to share to make them easily accessible
-install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/examples DESTINATION share)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/examples DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
BEGINRELEASENOTES
- Examples and other shared resources should go to `<prefix>/share/k4MarlinWrapper` in order for `key4hep-stack` environment variables to be properly populated. This fixes a problem where `$K4MARLINWRAPPER` points to an empty directory.
- Make sure to run the `doctest` workflows using the newly built version of `k4MarlinWrapper`
- Add `CEDViaWrapper` to the things that are run in the `doctest` workflow.
- Update github actions versions in CI.

ENDRELEASENOTES

- The [CEDViewer via wrapper example](https://github.com/key4hep/k4MarlinWrapper/blob/master/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md) is not currently run in the `doctest` workflow, otherwise we should have realized this much earlier. I am not yet entirely sure if we can run that in a non-interactive shell though.
  - [x] Check if the example can be run