### PR TITLE
put LCIO input files into global::parameters

### DIFF
--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -35,6 +35,7 @@ gaudi_add_module(k4MarlinWrapperPlugins
 target_include_directories(k4MarlinWrapperPlugins PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
   ${LCIO_INCLUDE_DIRS}
+  ${Marlin_INCLUDE_DIRS}
 )
 
 # MarlinWrapper
@@ -63,12 +64,14 @@ gaudi_add_module(EDM4hep2Lcio
     k4FWCore::k4FWCore
     Gaudi::GaudiAlgLib
     ${LCIO_LIBRARIES}
+    ${Marlin_LIBRARIES}
     EDM4HEP::edm4hep
 )
 
 target_include_directories(EDM4hep2Lcio PUBLIC
   ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
   ${LCIO_INCLUDE_DIRS}
+  ${Marlin_INCLUDE_DIRS}
 )
 
 # LCIO2EDM4hep

--- a/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
@@ -51,7 +51,6 @@
 // k4MarlinWrapper
 #include "k4MarlinWrapper/LCEventWrapper.h"
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
-#include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
 
 namespace marlin {
   class Processor;

--- a/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
@@ -24,11 +24,20 @@ namespace k4MW::util {
     return split(subject, re);
   }
 
-  /// singleton helper to intialise global Marlin parameters exactly once
-  const static marlin::StringParameters* marlin_global_parameters = ([]() {
-    marlin::Global::parameters = new marlin::StringParameters;
+  /// singleton helper to initialize global Marlin parameters exactly once. This
+  marlin::StringParameters* marlinGlobalParameters() {
+    static marlin::StringParameters p{};
+    const static auto               initMarlinGlobal = []() {
+      marlin::Global::parameters = &p;
+      return true;  // need a non-void return type
+    }();
+
     return marlin::Global::parameters;
-  })();
+  }
+
+  // Make sure that the initialization is done before any possible accesses to
+  // marlin::Global::parameters
+  const static auto* marlin_global_parameters = marlinGlobalParameters();
 
 }  // namespace k4MW::util
 

--- a/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "marlin/Global.h"
 #include "marlin/StringParameters.h"
 
 namespace k4MW::util {
@@ -23,11 +24,11 @@ namespace k4MW::util {
     return split(subject, re);
   }
 
-  /// singleton helper for global parameters
-  marlin::StringParameters* globalParameters(){
-    static marlin::StringParameters p ;
-    return &p ;
-  }
+  /// singleton helper to intialise global Marlin parameters exactly once
+  const static marlin::StringParameters* marlin_global_parameters = ( [](){
+      marlin::Global::parameters = new marlin::StringParameters ;
+      return marlin::Global::parameters;
+    }) ();
 
 }  // namespace k4MW::util
 

--- a/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "marlin/StringParameters.h"
+
 namespace k4MW::util {
 
   // Split a string by a regex
@@ -20,6 +22,13 @@ namespace k4MW::util {
     std::regex re{"\\s+"};
     return split(subject, re);
   }
+
+  /// singleton helper for global parameters
+  marlin::StringParameters* globalParameters(){
+    static marlin::StringParameters p ;
+    return &p ;
+  }
+
 }  // namespace k4MW::util
 
 #endif

--- a/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/util/k4MarlinWrapperUtil.h
@@ -25,10 +25,10 @@ namespace k4MW::util {
   }
 
   /// singleton helper to intialise global Marlin parameters exactly once
-  const static marlin::StringParameters* marlin_global_parameters = ( [](){
-      marlin::Global::parameters = new marlin::StringParameters ;
-      return marlin::Global::parameters;
-    }) ();
+  const static marlin::StringParameters* marlin_global_parameters = ([]() {
+    marlin::Global::parameters = new marlin::StringParameters;
+    return marlin::Global::parameters;
+  })();
 
 }  // namespace k4MW::util
 

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "k4MarlinWrapper/LcioEventAlgo.h"
-#include "marlin/Global.h"
 #include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
 
 DECLARE_COMPONENT(LcioEvent)
@@ -32,7 +31,6 @@ StatusCode LcioEvent::initialize() {
   if (sc.isFailure())
     return sc;
 
-  marlin::Global::parameters = k4MW::util::globalParameters() ;
   marlin::Global::parameters->add("LCIOInputFiles", m_fileNames ) ;
 
   m_reader = new MT::LCReader(0);

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -31,7 +31,7 @@ StatusCode LcioEvent::initialize() {
   if (sc.isFailure())
     return sc;
 
-  marlin::Global::parameters->add("LCIOInputFiles", m_fileNames ) ;
+  marlin::Global::parameters->add("LCIOInputFiles", m_fileNames);
 
   m_reader = new MT::LCReader(0);
   m_reader->open(m_fileNames);

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "k4MarlinWrapper/LcioEventAlgo.h"
+#include "marlin/Global.h"
+#include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
 
 DECLARE_COMPONENT(LcioEvent)
 
@@ -29,6 +31,9 @@ StatusCode LcioEvent::initialize() {
   StatusCode sc = GaudiAlgorithm::initialize();
   if (sc.isFailure())
     return sc;
+
+  marlin::Global::parameters = k4MW::util::globalParameters() ;
+  marlin::Global::parameters->add("LCIOInputFiles", m_fileNames ) ;
 
   m_reader = new MT::LCReader(0);
   m_reader->open(m_fileNames);

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -154,7 +154,6 @@ StatusCode MarlinProcessorWrapper::initialize() {
   if (once) {
     once = false;
     streamlog::out.init(std::cout, "k4MarlinWrapper");
-    marlin::Global::parameters = k4MW::util::globalParameters();
     marlin::Global::parameters->add("AllowToModifyEvent", {"true"});
 
     // Get seed set for random engine

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -23,6 +23,7 @@
 
 #include "k4MarlinWrapper/MarlinProcessorWrapper.h"
 #include "IMPL/LCEventImpl.h"
+#include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
 
 DECLARE_COMPONENT(MarlinProcessorWrapper)
 

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -154,7 +154,7 @@ StatusCode MarlinProcessorWrapper::initialize() {
   if (once) {
     once = false;
     streamlog::out.init(std::cout, "k4MarlinWrapper");
-    marlin::Global::parameters = new marlin::StringParameters();
+    marlin::Global::parameters = k4MW::util::globalParameters();
     marlin::Global::parameters->add("AllowToModifyEvent", {"true"});
 
     // Get seed set for random engine


### PR DESCRIPTION
BEGINRELEASENOTES
- LcioEventAlgo: put LCIO input files into global::parameters
   - needed e.g. by PatchCollection processor
   - done in LcioEventAlgo::init()
   - this fix is needed to be able to convert LCIO files to EDM4hep when not all collections are present in all events (default in ILD reconstruction)
- ensure marlin::Global:parameters is created exactly once

ENDRELEASENOTES
