### PR TITLE
Updating file fccRec_e4h_input.py

### DIFF
--- a/test/gaudi_opts/fccRec_e4h_input.py
+++ b/test/gaudi_opts/fccRec_e4h_input.py
@@ -59,23 +59,24 @@ MyAIDAProcessor.Parameters = {
                               }
 # EDM4hep to LCIO converter
 edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")
-edmConvTool.Parameters = [
-    'MCParticles',                     'MCParticles',
-    'VertexBarrelCollection',          'VertexBarrelCollection',
-    'VertexEndcapCollection',          'VertexEndcapCollection',
-    'InnerTrackerBarrelCollection',    'InnerTrackerBarrelCollection',
-    'OuterTrackerBarrelCollection',    'OuterTrackerBarrelCollection',
-    'InnerTrackerEndcapCollection',    'InnerTrackerEndcapCollection',
-    'OuterTrackerEndcapCollection',    'OuterTrackerEndcapCollection',
-    'ECalEndcapCollection',            'ECalEndcapCollection',
-    'ECalBarrelCollection',            'ECalBarrelCollection',
-    'HCalBarrelCollection',            'HCalBarrelCollection',
-    'HCalEndcapCollection',            'HCalEndcapCollection',
-    'HCalRingCollection',              'HCalRingCollection',
-    'YokeBarrelCollection',            'YokeBarrelCollection',
-    'YokeEndcapCollection',            'YokeEndcapCollection',
-    'LumiCalCollection',               'LumiCalCollection',
-]
+edmConvTool.convertAll = False
+edmConvTool.collNameMapping = {
+    'MCParticles':                     'MCParticles',
+    'VertexBarrelCollection':          'VertexBarrelCollection',
+    'VertexEndcapCollection':          'VertexEndcapCollection',
+    'InnerTrackerBarrelCollection':    'InnerTrackerBarrelCollection',
+    'OuterTrackerBarrelCollection':    'OuterTrackerBarrelCollection',
+    'InnerTrackerEndcapCollection':    'InnerTrackerEndcapCollection',
+    'OuterTrackerEndcapCollection':    'OuterTrackerEndcapCollection',
+    'ECalEndcapCollection':            'ECalEndcapCollection',
+    'ECalBarrelCollection':            'ECalBarrelCollection',
+    'HCalBarrelCollection':            'HCalBarrelCollection',
+    'HCalEndcapCollection':            'HCalEndcapCollection',
+    'HCalRingCollection':              'HCalRingCollection',
+    'YokeBarrelCollection':            'YokeBarrelCollection',
+    'YokeEndcapCollection':            'YokeEndcapCollection',
+    'LumiCalCollection':               'LumiCalCollection',
+}
 edmConvTool.OutputLevel = DEBUG
 MyAIDAProcessor.EDM4hep2LcioTool=edmConvTool
 
@@ -458,7 +459,7 @@ Output_REC.Parameters = {
 
 # LCIO to EDM4hep converter
 lcioConvTool = Lcio2EDM4hepTool("lcio2EDM4hep")
-lcioConvTool.Parameters = ["*"]
+lcioConvTool.convertAll = True
 lcioConvTool.OutputLevel = DEBUG
 Output_REC.Lcio2EDM4hepTool=lcioConvTool
 


### PR DESCRIPTION
BEGINRELEASENOTES
- The input file test/gaudi_opts/fccRec_e4h_input.py is now updated with changes introduced with https://github.com/key4hep/k4MarlinWrapper/pull/91

ENDRELEASENOTES

- Fix #104 
- Tests were not included yet for this specific file. 