### PR TITLE
Make it possible to run clic reco tests concurrently

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,11 @@ if (BASH_PROGRAM)
   # Test simple_processors2
   add_test( simple_processors2 ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/simple_processors2.sh )
 
+  # CLICPerformance setup is added as a simple test that will always succeed, on
+  # which other tests that need it can depend, in order to make concurrent
+  # running of those more easily possible
+  add_test( CLICPerformance_setup ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup_clic_performance.sh )
+
   # Test clicReconstruction
   add_test( clicRec ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec.sh )
 
@@ -78,5 +83,10 @@ if (BASH_PROGRAM)
       ENVIRONMENT "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH}"
       )
 
+    set_tests_properties(
+      clicRec clicRec_lcio_mt clicRec_edm4hep_input
+      PROPERTIES
+      DEPENDS CLICPerformance_setup
+      )
 
 endif(BASH_PROGRAM)

--- a/test/scripts/clicRec.sh
+++ b/test/scripts/clicRec.sh
@@ -3,9 +3,7 @@
 set -eu
 
 # Clone CLICPerformance for input files
-if [ ! -d CLICPerformance ]; then
-  git clone https://github.com/iLCSoft/CLICPerformance
-fi
+bash $TEST_DIR/scripts/setup_clic_performance.sh
 
 cd CLICPerformance/clicConfig
 

--- a/test/scripts/clicRec_e4h_input.sh
+++ b/test/scripts/clicRec_e4h_input.sh
@@ -3,9 +3,7 @@
 set -eu
 
 # Clone CLICPerformance for input files
-if [ ! -d CLICPerformance ]; then
-  git clone https://github.com/iLCSoft/CLICPerformance
-fi
+bash $TEST_DIR/scripts/setup_clic_performance.sh
 
 cd CLICPerformance/clicConfig
 

--- a/test/scripts/clicRec_lcio_mt.sh
+++ b/test/scripts/clicRec_lcio_mt.sh
@@ -3,9 +3,7 @@
 set -eu
 
 # Clone CLICPerformance for input files
-if [ ! -d CLICPerformance ]; then
-  git clone https://github.com/iLCSoft/CLICPerformance
-fi
+bash $TEST_DIR/scripts/setup_clic_performance.sh
 
 cd CLICPerformance/clicConfig
 

--- a/test/scripts/setup_clic_performance.sh
+++ b/test/scripts/setup_clic_performance.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [ ! -d CLICPerformance ]; then
+  git clone --depth=1 https://github.com/iLCSoft/CLICPerformance
+fi


### PR DESCRIPTION
BEGINRELEASENOTES
- Make it possible to run clic reco tests concurrently, by ensuring that cloning the CLICPerformance repository is not done concurrently by several test processes.
- Only get the last commit of CLICPerformance to speed up the cloning.

ENDRELEASENOTES
