### PR TITLE
Fix link in documentation

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -112,7 +112,7 @@ k4run clicReconstruction.py
 
 #### Reconstruction with EDM4hep input
 
-- When using **EDM4hep** format for the input events to be used in reconstruction, refer to the [**EDM converters**](https://github.com/key4hep/k4MarlinWrapper/blob/master/doc/edmConverters.md)
+- When using **EDM4hep** format for the input events to be used in reconstruction, refer to the [**EDM converters**](https://github.com/key4hep/k4MarlinWrapper/blob/master/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md)
 included with k4MarlinWrapper. Note that:
   + *MarlinProcessorWrappers* need input in LCIO format: EDM4hep collections need to be converted to LCIO
   + The output collections of *MarlinProcessorWrappers* may be used later by other algorithms:


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix link to edm converters documentation

ENDRELEASENOTES

Reported broken by CI of key4hep-doc: https://github.com/key4hep/key4hep-doc/actions/runs/4133418708/jobs/7164050580#step:6:118
