### PR TITLE
Transfer EventHeader information to LCIO event

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -90,6 +90,9 @@ private:
                           const std::string& e4h_coll_name, const std::string& lcio_coll_name,
                           lcio::LCEventImpl* lcio_event);
 
+  void convertEventHeader(const std::string& e4h_coll_name,
+                          lcio::LCEventImpl* lcio_event);
+
   void convertAdd(const std::string& e4h_coll_name, const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event,
                   CollectionsPairVectors& collection_pairs);
 };

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -90,8 +90,7 @@ private:
                           const std::string& e4h_coll_name, const std::string& lcio_coll_name,
                           lcio::LCEventImpl* lcio_event);
 
-  void convertEventHeader(const std::string& e4h_coll_name,
-                          lcio::LCEventImpl* lcio_event);
+  void convertEventHeader(const std::string& e4h_coll_name, lcio::LCEventImpl* lcio_event);
 
   void convertAdd(const std::string& e4h_coll_name, const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event,
                   CollectionsPairVectors& collection_pairs);

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -213,15 +213,14 @@ void EDM4hep2LcioTool::convertReconstructedParticles(
 }
 
 // Transfer info from EDM4hep EventHeader to LCIO event
-void EDM4hep2LcioTool::convertEventHeader(const std::string& e4h_coll_name, lcio::LCEventImpl* lcio_event)
-{
+void EDM4hep2LcioTool::convertEventHeader(const std::string& e4h_coll_name, lcio::LCEventImpl* lcio_event) {
   // ReconstructedParticles handle
   DataHandle<edm4hep::EventHeaderCollection> header_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
-  const auto header_coll = header_handle.get();
+  const auto                                 header_coll = header_handle.get();
 
-  const auto event_n = header_coll->eventNumber();
-  const auto run_n = header_coll->runNumber();
-  const auto timestamp = header_coll->timeStamp();
+  const auto event_n      = header_coll->eventNumber();
+  const auto run_n        = header_coll->runNumber();
+  const auto timestamp    = header_coll->timeStamp();
   const auto event_weight = header_coll->weight();
 
   // the collection returns vectors but they should be of length 1

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -217,6 +217,10 @@ void EDM4hep2LcioTool::convertEventHeader(const std::string& e4h_coll_name, lcio
   DataHandle<edm4hep::EventHeaderCollection> header_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto                                 header_coll = header_handle.get();
 
+  if (header_coll->size() != 1) {
+    error() << "Header collection contains " << header_coll->size() << " headers, expected 1." << endmsg;
+    return;
+  }
   convEventHeader(header_coll, lcio_event);
 }
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -306,7 +306,6 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
     }
   }
 
-  // TODO: warn here if EventHeader not there
   debug() << "Event: " << lcio_event->getEventNumber() << " Run: " << lcio_event->getRunNumber() << endmsg;
 
   FillMissingCollections(collection_pairs);

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -214,17 +214,16 @@ void EDM4hep2LcioTool::convertReconstructedParticles(
 
 // Transfer info from EDM4hep EventHeader to LCIO event
 void EDM4hep2LcioTool::convertEventHeader(const std::string& e4h_coll_name, lcio::LCEventImpl* lcio_event) {
-  // ReconstructedParticles handle
   DataHandle<edm4hep::EventHeaderCollection> header_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto                                 header_coll = header_handle.get();
 
-  const auto event_n      = header_coll->eventNumber();
-  const auto run_n        = header_coll->runNumber();
-  const auto timestamp    = header_coll->timeStamp();
-  const auto event_weight = header_coll->weight();
+  const auto& event_n      = header_coll->eventNumber();
+  const auto& run_n        = header_coll->runNumber();
+  const auto& timestamp    = header_coll->timeStamp();
+  const auto& event_weight = header_coll->weight();
 
   // the collection returns vectors but they should be of length 1
-  if (event_n.size() != 1 || run_n.size() != 1) {
+  if (event_n.size() != 1 || run_n.size() != 1 || timestamp.size() != 1 || event_weight.size() != 1) {
     // TODO: fail harder?
     error() << "Malformed EventHeader, multiple entries for event number, run number, timestamp or weight!" << endmsg;
     return;
@@ -319,7 +318,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   }
 
   // TODO: warn here if EventHeader not there
-  info() << "Event: " << lcio_event->getEventNumber() << " Run: " << lcio_event->getRunNumber() << endmsg;
+  debug() << "Event: " << lcio_event->getEventNumber() << " Run: " << lcio_event->getRunNumber() << endmsg;
 
   FillMissingCollections(collection_pairs);
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -217,22 +217,7 @@ void EDM4hep2LcioTool::convertEventHeader(const std::string& e4h_coll_name, lcio
   DataHandle<edm4hep::EventHeaderCollection> header_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto                                 header_coll = header_handle.get();
 
-  const auto& event_n      = header_coll->eventNumber();
-  const auto& run_n        = header_coll->runNumber();
-  const auto& timestamp    = header_coll->timeStamp();
-  const auto& event_weight = header_coll->weight();
-
-  // the collection returns vectors but they should be of length 1
-  if (event_n.size() != 1 || run_n.size() != 1 || timestamp.size() != 1 || event_weight.size() != 1) {
-    // TODO: fail harder?
-    error() << "Malformed EventHeader, multiple entries for event number, run number, timestamp or weight!" << endmsg;
-    return;
-  }
-
-  lcio_event->setEventNumber(event_n[0]);
-  lcio_event->setRunNumber(run_n[0]);
-  lcio_event->setTimeStamp(timestamp[0]);
-  lcio_event->setWeight(event_weight[0]);
+  convEventHeader(header_coll, lcio_event);
 }
 
 // Select the appropiate method to convert a collection given its type


### PR DESCRIPTION
BEGINRELEASENOTES
- edm4hep2lcio conversion: Transfer run and event number from edm4hep EventHeader to LCIO event. Fixes #110 

ENDRELEASENOTES

There are still some TODOs in here where I was not sure what the best option to warn the user would be.

Depends on https://github.com/key4hep/k4EDM4hep2LcioConv/pull/13