### PR TITLE
[clang-format] Fix formatting

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -65,8 +65,9 @@ private:
                                  const std::string& e4h_coll_name, const std::string& lcio_coll_name,
                                  lcio::LCEventImpl* lcio_event);
 
-  void convertTPCHits(vec_pair<lcio::TPCHitImpl*, edm4hep::RawTimeSeries>& tpc_hits_vec, const std::string& e4h_coll_name,
-                      const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);
+  void convertTPCHits(vec_pair<lcio::TPCHitImpl*, edm4hep::RawTimeSeries>& tpc_hits_vec,
+                      const std::string& e4h_coll_name, const std::string& lcio_coll_name,
+                      lcio::LCEventImpl* lcio_event);
 
   void convertClusters(vec_pair<lcio::ClusterImpl*, edm4hep::Cluster>&                     cluster_vec,
                        const vec_pair<lcio::CalorimeterHitImpl*, edm4hep::CalorimeterHit>& calohits_vec,

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/IEDMConverter.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/IEDMConverter.h
@@ -26,6 +26,8 @@
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
+#include <edm4hep/RawTimeSeries.h>
+#include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4hep/RecoParticleVertexAssociation.h>
 #include <edm4hep/RecoParticleVertexAssociationCollection.h>
 #include <edm4hep/ReconstructedParticle.h>
@@ -35,8 +37,6 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/SimTrackerHitCollection.h>
-#include <edm4hep/RawTimeSeries.h>
-#include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4hep/Track.h>
 #include <edm4hep/TrackCollection.h>
 #include <edm4hep/TrackerHit.h>

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -137,7 +137,7 @@ void EDM4hep2LcioTool::convertTPCHits(vec_pair<lcio::TPCHitImpl*, edm4hep::RawTi
                                       const std::string& e4h_coll_name, const std::string& lcio_coll_name,
                                       lcio::LCEventImpl* lcio_event) {
   DataHandle<edm4hep::RawTimeSeriesCollection> tpchit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
-  const auto                            tpchit_coll = tpchit_handle.get();
+  const auto                                   tpchit_coll = tpchit_handle.get();
 
   auto* conv_tpchits = convTPCHits(tpchit_coll, tpc_hits_vec);
 

--- a/test/src/TestE4H2L.cpp
+++ b/test/src/TestE4H2L.cpp
@@ -124,7 +124,8 @@ void TestE4H2L::createTPCHits(const int num_elements, const int num_rawwords, in
     }
   }
 
-  auto* tpchit_handle = dynamic_cast<DataHandle<edm4hep::RawTimeSeriesCollection>*>(m_dataHandlesMap[m_e4h_tpchit_name]);
+  auto* tpchit_handle =
+      dynamic_cast<DataHandle<edm4hep::RawTimeSeriesCollection>*>(m_dataHandlesMap[m_e4h_tpchit_name]);
   tpchit_handle->put(tpchit_coll);
 }
 
@@ -405,7 +406,7 @@ bool TestE4H2L::checkEDMSimCaloHitLCIOSimCaloHit(
 
 bool TestE4H2L::checkEDMTPCHitLCIOTPCHit(lcio::LCEventImpl* the_event) {
   DataHandle<edm4hep::RawTimeSeriesCollection> tpchit_handle_orig{m_e4h_tpchit_name, Gaudi::DataHandle::Reader, this};
-  const auto                            tpchit_coll_orig = tpchit_handle_orig.get();
+  const auto                                   tpchit_coll_orig = tpchit_handle_orig.get();
 
   auto lcio_tpchit_coll = the_event->getCollection(m_lcio_tpchit_name);
   auto lcio_coll_size   = lcio_tpchit_coll->getNumberOfElements();


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix formatting

ENDRELEASENOTES

Fixing formatting in a separate PR here to get the `clang-format-check` workflow working properly again and to declutter other PRs