### PR TITLE
Fix formatting and usage of Legacy components in tests

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -35,7 +35,7 @@ private:
   Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};
   Gaudi::Property<bool>                               m_convertAll{this, "convertAll", true};
 
-  PodioLegacyDataSvc*                   m_podioDataSvc;
+  PodioLegacyDataSvc*             m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
 
   void convertTracks(vec_pair<lcio::TrackImpl*, edm4hep::Track>&           tracks_vec,

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -34,7 +34,7 @@ private:
   std::map<std::string, DataObjectHandleBase*> m_dataHandlesMap;
 
   ServiceHandle<IDataProviderSvc> m_eds;
-  PodioLegacyDataSvc*                   m_podioDataSvc;
+  PodioLegacyDataSvc*             m_podioDataSvc;
 
   bool collectionExist(const std::string& collection_name);
 

--- a/test/gaudi_opts/clicRec_e4h_input.py
+++ b/test/gaudi_opts/clicRec_e4h_input.py
@@ -1,6 +1,6 @@
 from Gaudi.Configuration import *
 
-from Configurables import LcioEvent, k4DataSvc, MarlinProcessorWrapper
+from Configurables import LcioEvent, MarlinProcessorWrapper
 from k4MarlinWrapper.parseConstants import *
 algList = []
 
@@ -23,12 +23,12 @@ from Configurables import ToolSvc, Lcio2EDM4hepTool, EDM4hep2LcioTool
 # algList.append(read)
 
 
-from Configurables import k4DataSvc, PodioInput
-evtsvc = k4DataSvc('EventDataSvc')
+from Configurables import k4LegacyDataSvc, PodioLegacyInput
+evtsvc = k4LegacyDataSvc('EventDataSvc')
 evtsvc.input = '$TEST_DIR/inputFiles/ttbar1_edm4hep.root'
 
 
-inp = PodioInput('InputReader')
+inp = PodioLegacyInput('InputReader')
 inp.collections = [
   'EventHeader',
   'MCParticles',
@@ -1765,8 +1765,8 @@ VertexFinderUnconstrained.Parameters = {
 
 
 # Write output to EDM4hep
-from Configurables import PodioOutput
-out = PodioOutput("PodioOutput", filename = "my_output.root")
+from Configurables import PodioLegacyOutput
+out = PodioLegacyOutput("PodioOutput", filename = "my_output.root")
 out.outputCommands = ["keep *"]
 
 

--- a/test/gaudi_opts/edm_converters.py
+++ b/test/gaudi_opts/edm_converters.py
@@ -1,12 +1,12 @@
 from Gaudi.Configuration import *
 
-from Configurables import k4DataSvc, TestE4H2L, EDM4hep2LcioTool, Lcio2EDM4hepTool
+from Configurables import k4LegacyDataSvc, TestE4H2L, EDM4hep2LcioTool, Lcio2EDM4hepTool
 
 algList = []
 
 END_TAG = "END_TAG"
 
-evtsvc = k4DataSvc('EventDataSvc')
+evtsvc = k4LegacyDataSvc("EventDataSvc")
 
 # EDM4hep2lcio Tool
 edmConvTool = EDM4hep2LcioTool("EDM4hep2lcio")


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix formatting
- Switch python option files to use `Legacy` components as well for tests

ENDRELEASENOTES

- [x] Needs key4hep/k4FWCore#117