### PR TITLE
Rename CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ gaudi_add_module(TestE4H2L
 
 target_include_directories(TestE4H2L PUBLIC
   src
-  ${CMAKE_SOURCE_DIR}/k4MarlinWrapper
+  ${PROJECT_SOURCE_DIR}/k4MarlinWrapper
   k4FWCore::k4FWCore
   EDM4HEP::edm4hep
   ${LCIO_INCLUDE_DIRS}


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR

ENDRELEASENOTES

Continuation of https://github.com/key4hep/k4MarlinWrapper/pull/121