### PR TITLE
Don't use run to run k4run

### DIFF
--- a/test/scripts/clicRec_lcio_mt.sh
+++ b/test/scripts/clicRec_lcio_mt.sh
@@ -17,7 +17,7 @@ if [ ! -f clicReconstruction_mt.py ]; then
   ln -s $TEST_DIR/gaudi_opts/clicReconstruction_mt.py clicReconstruction_mt.py
 fi
 
-../../../run k4run clicReconstruction_mt.py
+k4run clicReconstruction_mt.py
 
 input_num_events=$(lcio_event_counter $TEST_DIR/inputFiles/testSimulation.slcio)
 output_num_events=$(lcio_event_counter MT_Output_REC.slcio)

--- a/test/scripts/same_num_io.sh
+++ b/test/scripts/same_num_io.sh
@@ -9,7 +9,7 @@ if [ ! -f $TEST_DIR/inputFiles/muons.slcio ]; then
   wget https://github.com/AIDASoft/DD4hep/raw/master/DDTest/inputFiles/muons.slcio -P $TEST_DIR/inputFiles/
 fi
 
-../run k4run $TEST_DIR/gaudi_opts/same_num_io.py --num-events=-1
+k4run $TEST_DIR/gaudi_opts/same_num_io.py --num-events=-1
 
 input_num_events=$(lcio_event_counter $TEST_DIR/inputFiles/muons.slcio)
 output_num_events=$(lcio_event_counter Output_DST.slcio)


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove run (autogenerated script to set up the environment) from some tests that use it together with k4run; we should set up the environment either in `CMakeLists.txt` or externally. 

ENDRELEASENOTES

Either we set the environment externally or in CMakeLists.txt but don't use run and force some relative paths that may or may not be how it is built. I tested this and both test work fine