### PR TITLE
Use K4GEO instead of a hardcoded path in cvmfs

### DIFF
--- a/test/gaudi_opts/converterConstants.py
+++ b/test/gaudi_opts/converterConstants.py
@@ -9,7 +9,7 @@ evtsvc = EventDataSvc()
 CONSTANTS = {
              'DetectorModel': "CLIC_o2_v04",
              'MyCompact': "compact",
-             'DD4hepXMLFile_subPath': "/cvmfs/sw.hsf.org/spackages/linux-centos7-x86_64/gcc-8.3.0/lcgeo-0.16.6-vbidketl5esynx6pmkrdnqrnfyf3m2vf/share/lcgeo/compact/CLIC/%(MyCompact)s/%(DetectorModel)s/%(DetectorModel)s.xml",
+             'DD4hepXMLFile_subPath': "$K4GEO/CLIC/%(MyCompact)s/%(DetectorModel)s/%(DetectorModel)s.xml",
              'MyResTest': "0.003",
              'MyResTest2': "003",
              'MyResTest3': "0.",

--- a/test/inputFiles/converterConstants.xml
+++ b/test/inputFiles/converterConstants.xml
@@ -3,7 +3,7 @@
   <constants>
     <constant name="DetectorModel" value="CLIC_o2_v04" />
     <constant name="MyCompact" value="compact" />
-    <constant name="DD4hepXMLFile_subPath" value="/cvmfs/sw.hsf.org/spackages/linux-centos7-x86_64/gcc-8.3.0/lcgeo-0.16.6-vbidketl5esynx6pmkrdnqrnfyf3m2vf/share/lcgeo/compact/CLIC/${MyCompact}/${DetectorModel}/${DetectorModel}.xml" />
+    <constant name="DD4hepXMLFile_subPath" value="$K4GEO/CLIC/${MyCompact}/${DetectorModel}/${DetectorModel}.xml" />
     <constant name="MyResTest">0.003</constant>
     <constant name="MyResTest2">003</constant>
     <constant name="MyResTest3">0.</constant>


### PR DESCRIPTION
BEGINRELEASENOTES
- Use K4GEO instead of a hardcoded path in cvmfs for the converter_constants test

ENDRELEASENOTES

Helps in case there is no cvmfs access, like on the nodes where the key4hep stack is built. Note that the python file is overwritten based on the xml file but I changed to what it will become.