### PR TITLE
Change the file names of the output files of some tests to avoid clashes

### DIFF
--- a/test/gaudi_opts/clicRec_e4h_input.py
+++ b/test/gaudi_opts/clicRec_e4h_input.py
@@ -923,7 +923,7 @@ Output_REC.Parameters = {
                          "DropCollectionTypes": [],
                          "FullSubsetCollections": ["EfficientMCParticles", "InefficientMCParticles"],
                          "KeepCollectionNames": [],
-                         "LCIOOutputFile": ["Output_REC.slcio"],
+                         "LCIOOutputFile": ["Output_REC_e4h_input.slcio"],
                          "LCIOWriteMode": ["WRITE_NEW"]
                          }
 
@@ -935,7 +935,7 @@ Output_DST.Parameters = {
                          "DropCollectionTypes": ["MCParticle", "LCRelation", "SimCalorimeterHit", "CalorimeterHit", "SimTrackerHit", "TrackerHit", "TrackerHitPlane", "Track", "ReconstructedParticle", "LCFloatVec", "Clusters"],
                          "FullSubsetCollections": ["EfficientMCParticles", "InefficientMCParticles", "MCPhysicsParticles"],
                          "KeepCollectionNames": ["MCParticlesSkimmed", "MCPhysicsParticles", "RecoMCTruthLink", "SiTracks", "SiTracks_Refitted", "PandoraClusters", "PandoraPFOs", "SelectedPandoraPFOs", "LooseSelectedPandoraPFOs", "TightSelectedPandoraPFOs", "LE_SelectedPandoraPFOs", "LE_LooseSelectedPandoraPFOs", "LE_TightSelectedPandoraPFOs", "LumiCalClusters", "LumiCalRecoParticles", "BeamCalClusters", "BeamCalRecoParticles", "MergedRecoParticles", "MergedClusters", "RefinedVertexJets", "RefinedVertexJets_rel", "RefinedVertexJets_vtx", "RefinedVertexJets_vtx_RP", "BuildUpVertices", "BuildUpVertices_res", "BuildUpVertices_RP", "BuildUpVertices_res_RP", "BuildUpVertices_V0", "BuildUpVertices_V0_res", "BuildUpVertices_V0_RP", "BuildUpVertices_V0_res_RP", "PrimaryVertices", "PrimaryVertices_res", "PrimaryVertices_RP", "PrimaryVertices_res_RP", "RefinedVertices", "RefinedVertices_RP"],
-                         "LCIOOutputFile": ["Output_DST.slcio"],
+                         "LCIOOutputFile": ["Output_DST_e4h_input.slcio"],
                          "LCIOWriteMode": ["WRITE_NEW"]
                          }
 

--- a/test/gaudi_opts/clicReconstruction_mt.py
+++ b/test/gaudi_opts/clicReconstruction_mt.py
@@ -1334,7 +1334,7 @@ Output_DST.Parameters = {
                          "DropCollectionTypes": ["MCParticle", "LCRelation", "SimCalorimeterHit", "CalorimeterHit", "SimTrackerHit", "TrackerHit", "TrackerHitPlane", "Track", "ReconstructedParticle", "LCFloatVec", "Clusters"],
                          "FullSubsetCollections": ["EfficientMCParticles", "InefficientMCParticles", "MCPhysicsParticles"],
                          "KeepCollectionNames": ["MCParticlesSkimmed", "MCPhysicsParticles", "RecoMCTruthLink", "SiTracks", "SiTracks_Refitted", "PandoraClusters", "PandoraPFOs", "SelectedPandoraPFOs", "LooseSelectedPandoraPFOs", "TightSelectedPandoraPFOs", "LE_SelectedPandoraPFOs", "LE_LooseSelectedPandoraPFOs", "LE_TightSelectedPandoraPFOs", "LumiCalClusters", "LumiCalRecoParticles", "BeamCalClusters", "BeamCalRecoParticles", "MergedRecoParticles", "MergedClusters", "RefinedVertexJets", "RefinedVertexJets_rel", "RefinedVertexJets_vtx", "RefinedVertexJets_vtx_RP", "BuildUpVertices", "BuildUpVertices_res", "BuildUpVertices_RP", "BuildUpVertices_res_RP", "BuildUpVertices_V0", "BuildUpVertices_V0_res", "BuildUpVertices_V0_RP", "BuildUpVertices_V0_res_RP", "PrimaryVertices", "PrimaryVertices_res", "PrimaryVertices_RP", "PrimaryVertices_res_RP", "RefinedVertices", "RefinedVertices_RP"],
-                         "LCIOOutputFile": ["Output_DST.slcio"],
+                         "LCIOOutputFile": ["Output_DST_mt_wrapper.slcio"],
                          "LCIOWriteMode": ["WRITE_NEW"]
                          }
 
@@ -1346,7 +1346,7 @@ Output_REC.Parameters = {
                          "DropCollectionTypes": [],
                          "FullSubsetCollections": ["EfficientMCParticles", "InefficientMCParticles"],
                          "KeepCollectionNames": [],
-                         "LCIOOutputFile": ["Output_REC.slcio"],
+                         "LCIOOutputFile": ["Output_REC_mt_wrapper.slcio"],
                          "LCIOWriteMode": ["WRITE_NEW"]
                          }
 
@@ -1360,7 +1360,7 @@ MyLcioEventOutput_DST.DropCollectionNames = []
 MyLcioEventOutput_DST.DropCollectionTypes = ["MCParticle", "LCRelation", "SimCalorimeterHit", "CalorimeterHit", "SimTrackerHit", "TrackerHit", "TrackerHitPlane", "Track", "ReconstructedParticle", "LCFloatVec", "Clusters"]
 MyLcioEventOutput_DST.FullSubsetCollections = ["EfficientMCParticles", "InefficientMCParticles", "MCPhysicsParticles"]
 MyLcioEventOutput_DST.KeepCollectionNames = ["MCParticlesSkimmed", "MCPhysicsParticles", "RecoMCTruthLink", "SiTracks", "SiTracks_Refitted", "PandoraClusters", "PandoraPFOs", "SelectedPandoraPFOs", "LooseSelectedPandoraPFOs", "TightSelectedPandoraPFOs", "LE_SelectedPandoraPFOs", "LE_LooseSelectedPandoraPFOs", "LE_TightSelectedPandoraPFOs", "LumiCalClusters", "LumiCalRecoParticles", "BeamCalClusters", "BeamCalRecoParticles", "MergedRecoParticles", "MergedClusters", "RefinedVertexJets", "RefinedVertexJets_rel", "RefinedVertexJets_vtx", "RefinedVertexJets_vtx_RP", "BuildUpVertices", "BuildUpVertices_res", "BuildUpVertices_RP", "BuildUpVertices_res_RP", "BuildUpVertices_V0", "BuildUpVertices_V0_res", "BuildUpVertices_V0_RP", "BuildUpVertices_V0_res_RP", "PrimaryVertices", "PrimaryVertices_res", "PrimaryVertices_RP", "PrimaryVertices_res_RP", "RefinedVertices", "RefinedVertices_RP"]
-MyLcioEventOutput_DST.OutputFileName = "MT_Output_DST.slcio"
+MyLcioEventOutput_DST.OutputFileName = "Output_DST_mt_lcio.slcio"
 MyLcioEventOutput_DST.WriteMode = "WRITE_NEW"
 
 
@@ -1370,7 +1370,7 @@ MyLcioEventOutput_REC.DropCollectionNames = []
 MyLcioEventOutput_REC.DropCollectionTypes = []
 MyLcioEventOutput_REC.FullSubsetCollections = ["EfficientMCParticles", "InefficientMCParticles"]
 MyLcioEventOutput_REC.KeepCollectionNames = []
-MyLcioEventOutput_REC.OutputFileName = "MT_Output_REC.slcio"
+MyLcioEventOutput_REC.OutputFileName = "Output_REC_mt_lcio.slcio"
 MyLcioEventOutput_REC.WriteMode = "WRITE_NEW"
 
 

--- a/test/inputFiles/anajob_Output_DST.expected
+++ b/test/inputFiles/anajob_Output_DST.expected
@@ -1,10 +1,10 @@
 anajob:  will open and read from files: 
 
-     Output_DST.slcio     [ number of runs: 0, number of events: 3 ] 
+     Output_DST_e4h_input.slcio     [ number of runs: 0, number of events: 3 ] 
 
 
  will reopen and read from files: 
-     Output_DST.slcio
+     Output_DST_e4h_input.slcio
 ///////////////////////////////////
 EVENT: 0
 RUN: 0
@@ -139,4 +139,4 @@ TightSelectedPandoraPFOs      ReconstructedParticle           57
 
 
   3 events read from files: 
-     Output_DST.slcio
+     Output_DST_e4h_input.slcio

--- a/test/inputFiles/anajob_Output_REC.expected
+++ b/test/inputFiles/anajob_Output_REC.expected
@@ -1,10 +1,10 @@
 anajob:  will open and read from files: 
 
-     Output_REC.slcio     [ number of runs: 0, number of events: 3 ] 
+     Output_REC_e4h_input.slcio     [ number of runs: 0, number of events: 3 ] 
 
 
  will reopen and read from files: 
-     Output_REC.slcio
+     Output_REC_e4h_input.slcio
 ///////////////////////////////////
 EVENT: 0
 RUN: 0
@@ -277,4 +277,4 @@ YokeEndcapCollection          SimCalorimeterHit                6
 
 
   3 events read from files: 
-     Output_REC.slcio
+     Output_REC_e4h_input.slcio

--- a/test/scripts/clicRec.sh
+++ b/test/scripts/clicRec.sh
@@ -30,7 +30,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile": \[".*"\],; "DD4hepXMLFile": \[os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\],;' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile": \[".*"\],; "DD4hepXMLFile": \[os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\],;' clicReconstruction.py
 # Change output level for correct test confirmation
 sed -i 's;OutputLevel=WARNING; OutputLevel=DEBUG;' clicReconstruction.py
 

--- a/test/scripts/clicRec_e4h_input.sh
+++ b/test/scripts/clicRec_e4h_input.sh
@@ -25,14 +25,14 @@ if [ "$input_num_events" != "$output_num_events" ]; then
 fi
 
 # Second check: contents (at least superficially)
-echo "Comparing contents of Output_REC.slcio"
-if ! diff <(anajob Output_REC.slcio) $TEST_DIR/inputFiles/anajob_Output_REC.expected; then
+echo "Comparing contents of Output_REC_e4h_input.slcio"
+if ! diff <(anajob Output_REC_e4h_input.slcio) $TEST_DIR/inputFiles/anajob_Output_REC.expected; then
   echo "File contents of REC slcio file are not as expected"
   exit 1
 fi
 
-echo "Comparing contents of Output_DST.slcio"
-if ! diff <(anajob Output_DST.slcio) $TEST_DIR/inputFiles/anajob_Output_DST.expected; then
+echo "Comparing contents of Output_DST_e4h_input.slcio"
+if ! diff <(anajob Output_DST_e4h_input.slcio) $TEST_DIR/inputFiles/anajob_Output_DST.expected; then
   echo "File contents of DST slcio file are not as expected"
   exit 1
 fi

--- a/test/scripts/clicRec_lcio_mt.sh
+++ b/test/scripts/clicRec_lcio_mt.sh
@@ -20,7 +20,7 @@ fi
 k4run clicReconstruction_mt.py
 
 input_num_events=$(lcio_event_counter $TEST_DIR/inputFiles/testSimulation.slcio)
-output_num_events=$(lcio_event_counter MT_Output_REC.slcio)
+output_num_events=$(lcio_event_counter Output_REC_mt_lcio.slcio)
 
 echo $input_num_events 
 echo $output_num_events


### PR DESCRIPTION
BEGINRELEASENOTES
- Change the file names of the output files of some tests to avoid clashes. Fixes running tests in parallel

ENDRELEASENOTES

and possibly failures in the CI tests that I was not able to reproduce locally.

For the changes in the expected output, alternatively, we could grep in the diff to avoid the file names so that they work for any file name; anyway if the content is different it's going to fail regardless of the file name