### PR TITLE
TrackingCellIDEncodingSvc: add service to set the Cell ID encoding st…

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -158,3 +158,23 @@ result=$?
 [ $result = "0" ] || [ $result = "4" ] && true
 ```
 
+### DD4hep Geometry Information
+
+The ``MarlinDD4hep::InitializeDD4hep`` processor can be replaced by the ``k4SimGeant4::GeoSvc`` and the
+``TrackingCellIDEncodingSvc`` the latter of which is part of the k4MarlinWrapper repository.
+
+For example:
+
+```python
+svcList = []
+geoservice = GeoSvc("GeoSvc")
+geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]
+geoservice.OutputLevel = INFO
+geoservice.EnableGeant4Geo = False
+svcList.append(geoservice)
+
+cellIDSvc = TrackingCellIDEncodingSvc("CellIDSvc")
+cellIDSvc.EncodingStringParameterName = "GlobalTrackerReadoutID"
+cellIDSvc.OutputLevel = INFO
+svcList.append(cellIDSvc)
+```

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -166,6 +166,7 @@ The ``MarlinDD4hep::InitializeDD4hep`` processor can be replaced by the ``k4SimG
 For example:
 
 ```python
+from Configurables import GeoSvc, TrackingCellIDEncodingSvc
 svcList = []
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]
@@ -175,6 +176,7 @@ svcList.append(geoservice)
 
 cellIDSvc = TrackingCellIDEncodingSvc("CellIDSvc")
 cellIDSvc.EncodingStringParameterName = "GlobalTrackerReadoutID"
+cellIDSvc.GeoSvcName = geoservice.name()
 cellIDSvc.OutputLevel = INFO
 svcList.append(cellIDSvc)
 ```

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -167,7 +167,7 @@ For example:
 
 ```python
 import os
-from Configurables import GeoSvc, TrackingCellIDEncodingSvc
+from Configurables import GeoSvc, TrackingCellIDEncodingSvc, INFO
 svcList = []
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -166,6 +166,7 @@ The ``MarlinDD4hep::InitializeDD4hep`` processor can be replaced by the ``k4SimG
 For example:
 
 ```python
+import os
 from Configurables import GeoSvc, TrackingCellIDEncodingSvc
 svcList = []
 geoservice = GeoSvc("GeoSvc")

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -167,7 +167,8 @@ For example:
 
 ```python
 import os
-from Configurables import GeoSvc, TrackingCellIDEncodingSvc, INFO
+from Gaudi.Configuration import INFO
+from Configurables import GeoSvc, TrackingCellIDEncodingSvc
 svcList = []
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]

--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -40,9 +40,11 @@ target_include_directories(k4MarlinWrapperPlugins PUBLIC
 gaudi_add_module(MarlinWrapper
   SOURCES
     src/components/MarlinProcessorWrapper.cpp
+    src/components/TrackingCellIDEncodingSvc.cpp
   LINK
     Gaudi::GaudiAlgLib
     k4FWCore::k4FWCore
+    k4FWCore::k4Interface
     ${Marlin_LIBRARIES}
     EDM4HEP::edm4hep
 )

--- a/k4MarlinWrapper/k4MarlinWrapper/TrackingCellIDEncodingSvc.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/TrackingCellIDEncodingSvc.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019-2023 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CELLIDSVC_H
+#define CELLIDSVC_H
+
+#include <GaudiKernel/Service.h>
+
+//LCIO Includes
+#include <UTIL/LCTrackerConf.h>
+
+#include <string>
+
+class IGeoSvc;
+
+class TrackingCellIDEncodingSvc : public extends<Service, IService> {
+public:
+  TrackingCellIDEncodingSvc(const std::string& name, ISvcLocator* svc);
+
+  virtual ~TrackingCellIDEncodingSvc();
+  virtual StatusCode initialize() final;
+  virtual StatusCode finalize() final;
+
+  /// Property to configure which DD4hep constant to use for the encodingString
+  Gaudi::Property<std::string> m_encodingStringVariable{
+      this, "EncodingStringParameterName", "GlobalTrackerReadoutID",
+      "The name of the DD4hep constant that contains the Encoding string for tracking detectors"};
+
+private:
+  SmartIF<IGeoSvc> m_geoSvc;
+};
+
+#endif  // CELLIDSVC_H

--- a/k4MarlinWrapper/k4MarlinWrapper/TrackingCellIDEncodingSvc.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/TrackingCellIDEncodingSvc.h
@@ -32,14 +32,16 @@ class TrackingCellIDEncodingSvc : public extends<Service, IService> {
 public:
   TrackingCellIDEncodingSvc(const std::string& name, ISvcLocator* svc);
 
-  virtual ~TrackingCellIDEncodingSvc();
-  virtual StatusCode initialize() final;
-  virtual StatusCode finalize() final;
+  ~TrackingCellIDEncodingSvc();
+  StatusCode initialize() final;
+  StatusCode finalize() final;
 
   /// Property to configure which DD4hep constant to use for the encodingString
   Gaudi::Property<std::string> m_encodingStringVariable{
       this, "EncodingStringParameterName", "GlobalTrackerReadoutID",
       "The name of the DD4hep constant that contains the Encoding string for tracking detectors"};
+
+  Gaudi::Property<std::string> m_geoSvcName{this, "GeoSvcName", "GeoSvc", "The name of the GeoSvc instance"};
 
 private:
   SmartIF<IGeoSvc> m_geoSvc;

--- a/k4MarlinWrapper/src/components/TrackingCellIDEncodingSvc.cpp
+++ b/k4MarlinWrapper/src/components/TrackingCellIDEncodingSvc.cpp
@@ -26,12 +26,16 @@
 DECLARE_COMPONENT(TrackingCellIDEncodingSvc);
 
 TrackingCellIDEncodingSvc::TrackingCellIDEncodingSvc(const std::string& name, ISvcLocator* svc)
-    : base_class(name, svc), m_geoSvc(svc->service("GeoSvc")) {}
+    : base_class(name, svc) {}
 
 TrackingCellIDEncodingSvc::~TrackingCellIDEncodingSvc() {}
 
 StatusCode TrackingCellIDEncodingSvc::initialize() {
   try {
+    info() << "Looking for GeoSvc with the name" << m_geoSvcName.value() << endmsg;
+
+    m_geoSvc = serviceLocator()->service(m_geoSvcName);
+
     info() << "Taking the encoding string as specified in dd4hep constant: " << m_encodingStringVariable.value()
            << endmsg;
 

--- a/k4MarlinWrapper/src/components/TrackingCellIDEncodingSvc.cpp
+++ b/k4MarlinWrapper/src/components/TrackingCellIDEncodingSvc.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019-2023 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "k4MarlinWrapper/TrackingCellIDEncodingSvc.h"
+
+// k4fwcore
+#include <k4Interface/IGeoSvc.h>
+
+#include <GaudiKernel/MsgStream.h>
+
+DECLARE_COMPONENT(TrackingCellIDEncodingSvc);
+
+TrackingCellIDEncodingSvc::TrackingCellIDEncodingSvc(const std::string& name, ISvcLocator* svc)
+    : base_class(name, svc), m_geoSvc(svc->service("GeoSvc")) {}
+
+TrackingCellIDEncodingSvc::~TrackingCellIDEncodingSvc() {}
+
+StatusCode TrackingCellIDEncodingSvc::initialize() {
+  try {
+    info() << "Taking the encoding string as specified in dd4hep constant: " << m_encodingStringVariable.value()
+           << endmsg;
+
+    auto encodingString = m_geoSvc->constantAsString(m_encodingStringVariable.value());
+
+    info() << "LCTrackerCellID::_encoding will be set to " << encodingString << endmsg;
+
+    UTIL::LCTrackerCellID::instance().set_encoding_string(encodingString);
+
+    return StatusCode::SUCCESS;
+
+  } catch (std::exception& e) {
+    error() << "Failed to set the encoding string!\n";
+    error() << e.what() << endmsg;
+    return StatusCode::FAILURE;
+  }
+}
+
+StatusCode TrackingCellIDEncodingSvc::finalize() { return StatusCode::SUCCESS; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,6 +86,9 @@ if (BASH_PROGRAM)
   # Run clicReconstruction sequence with LCIO input and output, no converters, with inter-event parallelism
   add_test( clicRec_lcio_mt ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_lcio_mt.sh )
 
+  # Test the GeoSvc and TrackingCellIDEncodingSvc
+  add_test( clic_geo_test ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicGeoTest.sh )
+
   set_tests_properties (
       simple_processors
       simple_processors2
@@ -97,6 +100,7 @@ if (BASH_PROGRAM)
       same_num_io
       clicRec_lcio_mt
       clicRec_edm4hep_input
+      clic_geo_test
     PROPERTIES
       ENVIRONMENT "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH};EXAMPLE_DIR=${PROJECT_SOURCE_DIR}/k4MarlinWrapper/examples"
       )

--- a/test/gaudi_opts/geoTest_cld.py
+++ b/test/gaudi_opts/geoTest_cld.py
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
+
 from Gaudi.Configuration import *
 
 from Configurables import TrackingCellIDEncodingSvc, GeoSvc

--- a/test/gaudi_opts/geoTest_cld.py
+++ b/test/gaudi_opts/geoTest_cld.py
@@ -30,6 +30,7 @@ svcList.append(geoservice)
 
 cellIDSvc = TrackingCellIDEncodingSvc("CellIDSvc")
 cellIDSvc.EncodingStringParameterName = "GlobalTrackerReadoutID"
+cellIDSvc.GeoSvcName = geoservice.name()
 cellIDSvc.OutputLevel = DEBUG
 svcList.append(cellIDSvc)
 

--- a/test/gaudi_opts/geoTest_cld.py
+++ b/test/gaudi_opts/geoTest_cld.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2019-2023 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from Gaudi.Configuration import *
+
+from Configurables import TrackingCellIDEncodingSvc, GeoSvc
+algList = []
+svcList = []
+
+geoservice = GeoSvc("GeoSvc")
+geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]
+geoservice.OutputLevel = INFO
+geoservice.EnableGeant4Geo = False
+svcList.append(geoservice)
+
+cellIDSvc = TrackingCellIDEncodingSvc("CellIDSvc")
+cellIDSvc.EncodingStringParameterName = "GlobalTrackerReadoutID"
+cellIDSvc.OutputLevel = DEBUG
+svcList.append(cellIDSvc)
+
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg = algList,
+                EvtSel = 'NONE',
+                EvtMax = 3,
+                ExtSvc = svcList,
+                OutputLevel=WARNING
+              )

--- a/test/scripts/clicGeoTest.sh
+++ b/test/scripts/clicGeoTest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+##
+## Copyright (c) 2019-2023 Key4hep-Project.
+##
+## This file is part of Key4hep.
+## See https://key4hep.github.io/key4hep-doc/ for further info.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+# exit if command or variable fails
+set -eu
+
+k4run $TEST_DIR/gaudi_opts/geoTest_cld.py


### PR DESCRIPTION
…ring for iLCSoft track reconstruction

BEGINRELEASENOTES
- TrackingCellIDEncodingSvc: add service to set the Cell ID encoding string for iLCSoft track reconstruction

ENDRELEASENOTES

This is part of #27 

Depends on 
* key4hep/k4FWCore#142
* HEP-FCC/k4SimGeant4#47
