### PR TITLE
Fix clang warnings by adding final

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -49,8 +49,8 @@ class Lcio2EDM4hepTool : public GaudiTool, virtual public IEDMConverter {
 public:
   Lcio2EDM4hepTool(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~Lcio2EDM4hepTool();
-  virtual StatusCode initialize();
-  virtual StatusCode finalize();
+  StatusCode initialize() final;
+  StatusCode finalize() final;
 
   // **********************************
   // - Convert all collections indicated in Tool parameters


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix clang warning "inconsistent-missing-override" by adding final to some virtual functions

ENDRELEASENOTES

Same as https://github.com/key4hep/k4FWCore/pull/143