### PR TITLE
Fix a comment and check for the status code of a test

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
@@ -40,7 +40,7 @@ To create an input file for the event display we run a simple detector simulatio
 
 ```bash
 ddsim --steeringFile CLICPerformance/clicConfig/clic_steer.py \
-      --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+      --compactFile $K4GEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
       --enableGun \
       --gun.distribution uniform \
       --gun.particle gamma \

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -48,7 +48,7 @@ output in such format:
 ```bash
 cd CLICPerformance/clicConfig
 
-ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+ddsim --compactFile $K4GEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
       --outputFile ttbar_edm4hep.root \
       --steeringFile clic_steer.py \
       --inputFiles ../Tests/yyxyev_000.stdhep \
@@ -61,7 +61,7 @@ in such format:
 ```bash
 cd CLICPerformance/clicConfig
 
-ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+ddsim --compactFile $K4GEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
       --outputFile ttbar.slcio \
       --steeringFile clic_steer.py \
       --inputFiles ../Tests/yyxyev_000.stdhep \
@@ -79,7 +79,7 @@ To run the reconstruction with ``Marlin``:
 cd CLICPerformance/clicConfig
 
 Marlin clicReconstruction.xml \
-       --InitDD4hep.DD4hepXMLFile=$LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+       --InitDD4hep.DD4hepXMLFile=$K4GEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
        --global.LCIOInputFiles=ttbar.slcio \
        --global.MaxRecordNumber=3
 ```

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -138,8 +138,8 @@ included with k4MarlinWrapper. Note that:
     * Some *MarlinProcessorWrappers* may modify collections instead of producing new ones: the original EDM4hep collection wont be updated in this case and would need conversion from LCIO to EDM4hep.
 
 - To run *clicReconstruction* with EDM4hep format, use the steering file found in the `examples` folder of k4MarlinWrapper:
-`k4MarlinWrapper/examples/clicRec_e4h_input.py` (this also get's installed to `$K4MARLINWRAPPER/examples` in Key4hep releases)
-  + Change line `evtsvc.input = '$TEST_DIR/inputFiles/ttbar_edm4hep_frame.root'` to point to the location of your input file.
+`k4MarlinWrapper/examples/clicRec_e4h_input.py` (this also gets installed to `$K4MARLINWRAPPER/examples` in Key4hep releases)
+  + Change the line where `evtsvc.input` is defined to point to the location of your input file.
   + At the bottom of the file, in the `ApplicationMgr` parameters, change `EvtMax   = 3,` to the number of events to run.
 
 This can be run in the following way. Note that we show the usage here in a way

--- a/k4MarlinWrapper/examples/runit.py
+++ b/k4MarlinWrapper/examples/runit.py
@@ -58,7 +58,7 @@ proc1.OutputLevel = DEBUG
 proc1.ProcessorType = "InitializeDD4hep"
 proc1.Parameters = {#"EncodingStringParameter", "GlobalTrackerReadoutID"},
                     #"DD4hepXMLFile", "/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml"},
-                    "DD4hepXMLFile": [os.path.join(os.environ["LCGEO"], "CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml")],
+                    "DD4hepXMLFile": [os.path.join(os.environ["K4GEO"], "CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml")],
                     }
 algList.append(proc1)
 

--- a/test/gaudi_opts/clicReconstruction_mt.py
+++ b/test/gaudi_opts/clicReconstruction_mt.py
@@ -173,7 +173,7 @@ InitDD4hep = MarlinProcessorWrapper("InitDD4hep")
 InitDD4hep.OutputLevel = WARNING
 InitDD4hep.ProcessorType = "InitializeDD4hep"
 InitDD4hep.Parameters = {
-                          "DD4hepXMLFile": [os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"],
+                          "DD4hepXMLFile": [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"],
                          "EncodingStringParameter": ["GlobalTrackerReadoutID"]
                          }
 

--- a/test/gaudi_opts/simple_processors.py
+++ b/test/gaudi_opts/simple_processors.py
@@ -55,7 +55,7 @@ proc1 = MarlinProcessorWrapper("InitDD4hep")
 proc1.OutputLevel = DEBUG
 proc1.ProcessorType = "InitializeDD4hep"
 proc1.Parameters = {#"EncodingStringParameter": ["GlobalTrackerReadoutID"],
-                    "DD4hepXMLFile": [os.path.join(os.environ.get('LCGEO'), 'CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml')]
+                    "DD4hepXMLFile": [os.path.join(os.environ.get('K4GEO'), 'CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml')]
                     }
 algList.append(proc1)
 
@@ -84,3 +84,4 @@ ApplicationMgr( TopAlg = algList,
                 ExtSvc = [evtsvc],
                 OutputLevel=DEBUG
 )
+

--- a/test/gaudi_opts/simple_processors2.py
+++ b/test/gaudi_opts/simple_processors2.py
@@ -55,7 +55,7 @@ proc1 = MarlinProcessorWrapper("InitDD4hep")
 proc1.OutputLevel = DEBUG
 proc1.ProcessorType = "InitializeDD4hep"
 proc1.Parameters = {#"EncodingStringParameter": ["GlobalTrackerReadoutID"],
-                     "DD4hepXMLFile": [os.path.join(os.environ.get('LCGEO'), 'CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml')]
+                     "DD4hepXMLFile": [os.path.join(os.environ.get('K4GEO'), 'CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml')]
                     }
 algList.append(proc1)
 

--- a/test/gaudi_opts/simple_processors3.py
+++ b/test/gaudi_opts/simple_processors3.py
@@ -64,7 +64,7 @@ proc1 = MarlinProcessorWrapper("InitDD4hep")
 proc1.OutputLevel = DEBUG
 proc1.ProcessorType = "InitializeDD4hep"
 proc1.Parameters = {#"EncodingStringParameter": ["GlobalTrackerReadoutID"],
-                     "DD4hepXMLFile": [os.path.join(os.environ.get('LCGEO'), 'CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml')]
+                     "DD4hepXMLFile": [os.path.join(os.environ.get('K4GEO'), 'CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml')]
                     }
 algList.append(proc1)
 

--- a/test/scripts/clicRec_e4h_input.sh
+++ b/test/scripts/clicRec_e4h_input.sh
@@ -34,9 +34,7 @@ if [ ! -f $TEST_DIR/inputFiles/$INPUTFILE ]; then
   wget https://key4hep.web.cern.ch/testFiles/ddsimOutput/$INPUTFILE -P $TEST_DIR/inputFiles/
 fi
 
-# Frame based I/O exits with a user requested stop here, that makes Gaudi exit
-# with an exit code of 4. See https://github.com/key4hep/k4FWCore/issues/125
-k4run $EXAMPLE_DIR/clicRec_e4h_input.py || true
+k4run $EXAMPLE_DIR/clicRec_e4h_input.py
 
 input_num_events=$(python $TEST_DIR/python/root_num_events.py $TEST_DIR/inputFiles/$INPUTFILE)
 output_num_events=$(python $TEST_DIR/python/root_num_events.py my_output.root)


### PR DESCRIPTION
BEGINRELEASENOTES
- Docs: Correct the comment referring to the input file that has to be replaced
- Test: no longer ignore the return value of a test. It used to return 4, but that was fixed in  key4hep/k4fwcore#132
- Tests: Replace environment variable LCGEO with K4GEO following the usage in other key4hep repositories   

ENDRELEASENOTES

The line that was previously going to be substituted doesn't exist. There is an extra place where LCGEO appears: https://github.com/key4hep/k4MarlinWrapper/blob/main/doc/starterkit/k4MarlinWrapperCLIC/Readme.md?plain=1#L118
but that also requires changes in `CLICPerformance/clicConfig`