### PR TITLE
Make sure to import os in example and test gaudi opt files

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -108,6 +108,7 @@ during [Simulation](#simulation).
 ```bash
 cd CLICPerformance/clicConfig
 
+sed -i '1s/^/import os\n/' clicReconstruction.py
 sed -i 's;read.Files = \[".*"\];read.Files = \["ttbar.slcio"\];' clicReconstruction.py
 sed -i 's;EvtMax   = 10,;EvtMax   = 3,;' clicReconstruction.py
 sed -i 's;"MaxRecordNumber": ["10"],;"MaxRecordNumber": ["3"],;' clicReconstruction.py

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import os
+
 from Gaudi.Configuration import *
 
 from Configurables import LcioEvent, MarlinProcessorWrapper

--- a/test/gaudi_opts/clicReconstruction_mt.py
+++ b/test/gaudi_opts/clicReconstruction_mt.py
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
+
 from Gaudi.Configuration import *
 
 # Parallel stuff

--- a/test/scripts/clicRec.sh
+++ b/test/scripts/clicRec.sh
@@ -41,6 +41,7 @@ fi
 echo "Modifying clicReconstruction.py file..."
 # Replace SLCIO file path
 # sed -i 's|/run/simulation/with/ctest/to/create/a/file.slcio|testSimulation.slcio|g' clicReconstruction.py
+sed -i '1s/^/import os\n/' clicReconstruction.py
 sed -i 's|/run/simulation/with/ctest/to/create/a/file.slcio|$TEST_DIR/inputFiles/testSimulation.slcio|g' clicReconstruction.py
 # Uncomment selected optional processors
 sed -i 's;EvtMax   = 10,;EvtMax   = 3,;' clicReconstruction.py


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to have an `import os` in all gaudi options files that use `os` in some form. This becomes necessary after https://github.com/key4hep/k4FWCore/pull/134

ENDRELEASENOTES
