### PR TITLE
Make the conversion script exit early if include statements are found in the XML inputs

### DIFF
--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -248,9 +248,11 @@ def convertProcessors(lines, tree, globParams, constants):
 def findWarnIncludes(tree):
   """Check the parsed XML structure for include statments and issue a warning"""
   if any(True for _ in tree.iter("include")):
-    print("WARNING: Found at least one <include ref=\"...\"/> statement in the Marlin steering file")
-    print("         These cannot be handled by the conversion script.")
-    print("         Use Marlin -n <input-file> to resolve these includes and convert the output of that")
+    print("ERROR: Found at least one <include ref=\"...\"/> statement in the Marlin steering file")
+    print("       These cannot be handled by the conversion script.")
+    print("       Use Marlin -n <input-file> to resolve these includes and convert the output of that")
+
+    sys.exit(1)
 
 
 def generateGaudiSteering(tree):

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -86,10 +86,6 @@ def convertConstants(lines, tree):
   """ Find constant tags, write them to python and replace constants within themselves """
   constants = dict()
 
-  constElements = tree.findall('constants/include')
-  if constElements:
-    print('WARNING: include statements found inside constants tag')
-
   constElements = tree.findall('constants/constant')
   for const in constElements:
     constants[const.attrib.get('name')] = getValue(const)
@@ -249,7 +245,16 @@ def convertProcessors(lines, tree, globParams, constants):
   return lines
 
 
+def findWarnIncludes(tree):
+  """Check the parsed XML structure for include statments and issue a warning"""
+  if any(True for _ in tree.iter("include")):
+    print("WARNING: Found at least one <include ref=\"...\"/> statement in the Marlin steering file")
+    print("         These cannot be handled by the conversion script.")
+    print("         Use Marlin -n <input-file> to resolve these includes and convert the output of that")
+
+
 def generateGaudiSteering(tree):
+  findWarnIncludes(tree)
   globParams = getGlobalParameters(tree)
   lines = []
   createHeader(lines)


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a warning message to the steering file converter script to warn users about any `<include ref="..." />` statements in the original Marlin steering file.

ENDRELEASENOTES

@andresailer is a warning enough or should we even just exit with non-zero in this case?