### PR TITLE
Changes for included files

### DIFF
--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -268,14 +268,17 @@ def escapeIllegalChars(file_str):
   return file_str.replace("&&", "&amp;&amp;")
 
 
-def includeFiles(tree):
+def includeFiles(tree, infile):
   for p_item in tree.findall('.//include/..'):
     for if_item in p_item.findall('./include'):
       try:
-        with open(if_item.attrib['ref'], "r+") as iFile:
+        #TODO resolve path for part-files
+        nested_file = if_item.attrib['ref']
+        with open(nested_file, "r+") as iFile:
           # workaround: part files are not xml compliant
           fStr = r'<%s>%s</%s>' % (p_item.tag, escapeIllegalChars(iFile.read()), p_item.tag)
           iTree = ElementTree(fromstring(fStr))
+          includeFiles(iTree, nested_file)
           for e_item in iTree.findall('./*'):
             p_item.append(e_item)
       except Exception as ex:
@@ -293,7 +296,7 @@ def run(inputfile, outputfile):
     sys.exit(1)
 
   # TODO check compliance with https://www.w3.org/TR/xinclude/
-  includeFiles(tree)
+  includeFiles(tree, inputfile)
 
   with open(outputfile, 'w') as wf_file:
     wf_file.write("\n".join(generateGaudiSteering(tree)))

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 from copy import deepcopy
 import re
 import sys
+import os.path
 
 from xml.etree.ElementTree import fromstring, ElementTree
 
@@ -269,11 +270,13 @@ def escapeIllegalChars(file_str):
 
 
 def includeFiles(tree, infile):
+  wdir = os.path.dirname(os.path.abspath(infile))
   for p_item in tree.findall('.//include/..'):
     for if_item in p_item.findall('./include'):
       try:
-        #TODO resolve path for part-files
         nested_file = if_item.attrib['ref']
+        if not os.path.isabs(nested_file):
+            nested_file = os.path.join(wdir, nested_file)
         with open(nested_file, "r+") as iFile:
           # workaround: part files are not xml compliant
           fStr = r'<%s>%s</%s>' % (p_item.tag, escapeIllegalChars(iFile.read()), p_item.tag)


### PR DESCRIPTION
This is a simple patch for including part-files in the main steer file.
Unfortunately part-files are not xml compliant and should be included as raw ones.
An example of fragmented configuration is available at https://github.com/MuonColliderSoft/lcgeo/tree/master/MuColl/MuColl_v1