### PR TITLE
Always convert EventHeader to lcio

### DIFF
--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -51,7 +51,6 @@ evtsvc.input = os.path.join('$TEST_DIR/inputFiles/', os.environ.get("INPUTFILE",
 
 inp = PodioInput('InputReader')
 inp.collections = [
-  'EventHeader',
   'MCParticles',
   'VertexBarrelCollection',
   'VertexEndcapCollection',

--- a/k4MarlinWrapper/examples/event_display.py
+++ b/k4MarlinWrapper/examples/event_display.py
@@ -28,7 +28,6 @@ evtsvc.input = ''
 
 inp = PodioInput('InputReader')
 inp.collections = [
-  'EventHeader',
   'MCParticles',
   'VertexBarrelCollection',
   'VertexEndcapCollection',

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -320,7 +320,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   // Start off with the pre-defined collection name mappings
   auto collsToConvert{m_collNames.value()};
   // We *always* want to convert the EventHeader
-  collsToConvert.emplace("EventHeader", "EventHeader");
+  collsToConvert.emplace(edm4hep::EventHeaderName, "");
   if (m_convertAll) {
     info() << "Converting all collections from EDM4hep to LCIO" << endmsg;
     // And simply add the rest, exploiting the fact that emplace will not

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -319,6 +319,8 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   const auto collections = m_podioDataSvc->getEventFrame().getAvailableCollections();
   // Start off with the pre-defined collection name mappings
   auto collsToConvert{m_collNames.value()};
+  // We *always* want to convert the EventHeader
+  collsToConvert.emplace("EventHeader", "EventHeader");
   if (m_convertAll) {
     info() << "Converting all collections from EDM4hep to LCIO" << endmsg;
     // And simply add the rest, exploiting the fact that emplace will not

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -143,8 +143,8 @@ namespace {
 
 StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   // Convert Event Header outside the collections loop
-  if (!collectionExist("EventHeader")) {
-    registerCollection("EventHeader", LCIO2EDM4hepConv::createEventHeader(the_event));
+  if (!collectionExist(edm4hep::EventHeaderName)) {
+    registerCollection(edm4hep::EventHeaderName, LCIO2EDM4hepConv::createEventHeader(the_event));
   }
 
   // Start off with the pre-defined collection name mappings

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,6 +88,8 @@ if (BASH_PROGRAM)
   # multiple processors
   add_test( global_converter_maps ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/global_converter_maps.sh )
 
+  add_test( event_header ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/event_header.sh )
+
   set_tests_properties (
       simple_processors
       simple_processors2
@@ -100,6 +102,7 @@ if (BASH_PROGRAM)
       clicRec_edm4hep_input
       clic_geo_test
       global_converter_maps
+      event_header
     PROPERTIES
       ENVIRONMENT "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH};EXAMPLE_DIR=${PROJECT_SOURCE_DIR}/k4MarlinWrapper/examples;MARLIN_DLL=$ENV{MARLIN_DLL}:${CMAKE_CURRENT_BINARY_DIR}/libMarlinTestProcessors.so"
       )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,7 +102,7 @@ if (BASH_PROGRAM)
       clicRec_edm4hep_input
       clic_geo_test
       global_converter_maps
-      event_header
+      event_header_conversion
     PROPERTIES
       ENVIRONMENT "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH};EXAMPLE_DIR=${PROJECT_SOURCE_DIR}/k4MarlinWrapper/examples;MARLIN_DLL=$ENV{MARLIN_DLL}:${CMAKE_CURRENT_BINARY_DIR}/libMarlinTestProcessors.so"
       )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,7 +88,7 @@ if (BASH_PROGRAM)
   # multiple processors
   add_test( global_converter_maps ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/global_converter_maps.sh )
 
-  add_test( event_header ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/event_header.sh )
+  add_test( event_header_conversion ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/event_header.sh )
 
   set_tests_properties (
       simple_processors

--- a/test/gaudi_opts/createEventHeader.py
+++ b/test/gaudi_opts/createEventHeader.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2019-2023 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from Gaudi.Configuration import WARNING
+
+from Configurables import (
+    EventHeaderCreator,
+    k4DataSvc,
+    MarlinProcessorWrapper,
+    ApplicationMgr,
+    EDM4hep2LcioTool,
+)
+
+eventHeaderCreator = EventHeaderCreator("eventHeaderCreator", eventNumberOffset=42)
+
+podioevent = k4DataSvc("EventDataSvc")
+
+EDM4hep2Lcio = EDM4hep2LcioTool("EDM4hep2Lcio")
+EDM4hep2Lcio.convertAll = False
+
+out = MarlinProcessorWrapper("out")
+out.ProcessorType = "LCIOOutputProcessor"
+out.Parameters = {"LCIOOutputFile": ["test.slcio"], "LCIOWriteMode": ["WRITE_NEW"]}
+out.EDM4hep2LcioTool = EDM4hep2Lcio
+
+ApplicationMgr(
+    TopAlg=[
+        eventHeaderCreator,
+        out,
+    ],
+    EvtSel="NONE",
+    EvtMax=2,
+    ExtSvc=[podioevent],
+    OutputLevel=WARNING,
+)

--- a/test/gaudi_opts/fccRec_e4h_input.py
+++ b/test/gaudi_opts/fccRec_e4h_input.py
@@ -41,7 +41,6 @@ evtsvc.input = 'tops_edm4hep.root'
 
 inp = PodioInput('InputReader')
 inp.collections = [
-  'EventHeader',
   'MCParticles',
   'VertexBarrelCollection',
   'VertexEndcapCollection',

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -38,7 +38,7 @@ evtsvc.input = os.path.join(
 )
 
 podioInput = PodioInput("InputReader")
-podioInput.collections = ["MCParticles"]
+podioInput.collections = ["MCParticles", "EventHeader"]
 podioInput.OutputLevel = INFO
 
 PseudoRecoProc = MarlinProcessorWrapper("PseudoReco")

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -38,7 +38,7 @@ evtsvc.input = os.path.join(
 )
 
 podioInput = PodioInput("InputReader")
-podioInput.collections = ["MCParticles", "EventHeader"]
+podioInput.collections = ["MCParticles"]
 podioInput.OutputLevel = INFO
 
 PseudoRecoProc = MarlinProcessorWrapper("PseudoReco")

--- a/test/scripts/event_header.sh
+++ b/test/scripts/event_header.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+##
+## Copyright (c) 2019-2023 Key4hep-Project.
+##
+## This file is part of Key4hep.
+## See https://key4hep.github.io/key4hep-doc/ for further info.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -eu
+
+k4run $TEST_DIR/gaudi_opts/createEventHeader.py
+anajob test.slcio | grep "EVENT: 42"


### PR DESCRIPTION
BEGINRELEASENOTES
- Modified the edm4hep to lcio converter to always convert the`EventHeader` to have event number etc. available in lcio.

ENDRELEASENOTES

Does anyone have a good idea for a test?

Resolves: https://github.com/key4hep/k4MarlinWrapper/issues/153