### PR TITLE
Fleshed out instructions about DD4hep geometry information

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -156,7 +156,7 @@ k4run clicRec_e4h_input.py --EventDataSvc.input ttbar_edm4hep.root
 
 The ``MarlinDD4hep::InitializeDD4hep`` processor can be replaced by the ``k4SimGeant4::GeoSvc`` and the
 ``TrackingCellIDEncodingSvc`` the latter of which is part of the k4MarlinWrapper repository.
-This requires removing the `InitDD4hep` object from the `algList` and adding `geoservice` and `cellIDSvc` to the `svcList`.
+This requires removing the wrapped `InitDD4hep` processor from the `algList` and adding `geoservice` and `cellIDSvc` to the `ExtSvc` in the `ApplicationMgr`.
 
 We can create the `geoservice` and `cellIDSvc` with;
 

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -205,7 +205,7 @@ ApplicationMgr( TopAlg = algList,
               )
 ```
 
-changes to 
+changes to
 
 ```python
 ApplicationMgr( TopAlg = algList,

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -156,11 +156,24 @@ k4run clicRec_e4h_input.py --EventDataSvc.input ttbar_edm4hep.root
 
 The ``MarlinDD4hep::InitializeDD4hep`` processor can be replaced by the ``k4SimGeant4::GeoSvc`` and the
 ``TrackingCellIDEncodingSvc`` the latter of which is part of the k4MarlinWrapper repository.
-This requires removing the wrapped `InitDD4hep` processor from the `algList` and adding `geoservice` and `cellIDSvc` to the `ExtSvc` in the `ApplicationMgr`.
+This requires removing the wrapped `InitDD4hep` processor from the `algList` and the two new processed be appended to the `ExtSvc` argument in the `ApplicationMgr`.
 
-We can create the `geoservice` and `cellIDSvc` with;
+We will create another list, `svcList` for this.
+In the space following
 
 ```python
+from Configurables import k4DataSvc, PodioInput
+evtsvc = k4DataSvc('EventDataSvc')
+evtsvc.input = os.path.join('$TEST_DIR/inputFiles/', os.environ.get("INPUTFILE", "ttbar_edm4hep.root"))
+```
+
+we can start the `svcList` list and add the `GeoSvc` and `TrackingCellIDEncodingSvc` with;
+
+```python
+svcList = []
+svcList.append(evtsvc)
+
+
 import os
 from Gaudi.Configuration import INFO
 from Configurables import GeoSvc, TrackingCellIDEncodingSvc
@@ -169,16 +182,19 @@ geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]
 geoservice.OutputLevel = INFO
 geoservice.EnableGeant4Geo = False
+svcList.append(geoservice)
+
 
 cellIDSvc = TrackingCellIDEncodingSvc("CellIDSvc")
 cellIDSvc.EncodingStringParameterName = "GlobalTrackerReadoutID"
 cellIDSvc.GeoSvcName = geoservice.name()
 cellIDSvc.OutputLevel = INFO
+svcList.append(cellIDSvc)
 ```
 
 
-Then we need to make a `svcList` to add them to and pass that to the `ExtSvc` argument.
-At the bottom of the file, change
+Then all that is left is to pass that to the `ExtSvc` argument.
+At the bottom of the file;
 
 ```python
 ApplicationMgr( TopAlg = algList,
@@ -189,12 +205,9 @@ ApplicationMgr( TopAlg = algList,
               )
 ```
 
-to
+changes to 
 
 ```python
-svcList = [evtsvc]  # if an evtsvc is available
-svcList.append(geoservice)
-svcList.append(cellIDSvc)
 ApplicationMgr( TopAlg = algList,
                 EvtSel = 'NONE',
                 EvtMax   = 3,

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -192,7 +192,7 @@ ApplicationMgr( TopAlg = algList,
 to
 
 ```python
-svcList = [evtsvc]
+svcList = [evtsvc]  # if an evtsvc is available
 svcList.append(geoservice)
 svcList.append(cellIDSvc)
 ApplicationMgr( TopAlg = algList,

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -164,7 +164,6 @@ We can create the `geoservice` and `cellIDSvc` with;
 import os
 from Gaudi.Configuration import INFO
 from Configurables import GeoSvc, TrackingCellIDEncodingSvc
-svcList = []
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]
 geoservice.OutputLevel = INFO

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -156,8 +156,9 @@ k4run clicRec_e4h_input.py --EventDataSvc.input ttbar_edm4hep.root
 
 The ``MarlinDD4hep::InitializeDD4hep`` processor can be replaced by the ``k4SimGeant4::GeoSvc`` and the
 ``TrackingCellIDEncodingSvc`` the latter of which is part of the k4MarlinWrapper repository.
+This requires removing the `InitDD4hep` object from the `algList` and adding `geoservice` and `cellIDSvc` to the `svcList`.
 
-For example:
+We can create the `geoservice` and `cellIDSvc` with;
 
 ```python
 import os
@@ -168,11 +169,36 @@ geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]
 geoservice.OutputLevel = INFO
 geoservice.EnableGeant4Geo = False
-svcList.append(geoservice)
 
 cellIDSvc = TrackingCellIDEncodingSvc("CellIDSvc")
 cellIDSvc.EncodingStringParameterName = "GlobalTrackerReadoutID"
 cellIDSvc.GeoSvcName = geoservice.name()
 cellIDSvc.OutputLevel = INFO
+```
+
+
+Then we need to make a `svcList` to add them to.
+At the bottom of the file, change 
+
+```python
+ApplicationMgr( TopAlg = algList,
+                EvtSel = 'NONE',
+                EvtMax   = 3,
+                ExtSvc = [evtsvc],
+                OutputLevel=WARNING
+              )
+```
+
+to
+
+```python
+svcList = [evtsvc]
+svcList.append(geoservice)
 svcList.append(cellIDSvc)
+ApplicationMgr( TopAlg = algList,
+                EvtSel = 'NONE',
+                EvtMax   = 3,
+                ExtSvc = svcList,
+                OutputLevel=WARNING
+              )
 ```

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -176,7 +176,7 @@ cellIDSvc.OutputLevel = INFO
 ```
 
 
-Then we need to make a `svcList` to add them to.
+Then we need to make a `svcList` to add them to and pass that to the `ExtSvc` argument.
 At the bottom of the file, change 
 
 ```python

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -178,7 +178,7 @@ cellIDSvc.OutputLevel = INFO
 
 
 Then we need to make a `svcList` to add them to and pass that to the `ExtSvc` argument.
-At the bottom of the file, change 
+At the bottom of the file, change
 
 ```python
 ApplicationMgr( TopAlg = algList,

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -164,6 +164,7 @@ We can create the `geoservice` and `cellIDSvc` with;
 import os
 from Gaudi.Configuration import INFO
 from Configurables import GeoSvc, TrackingCellIDEncodingSvc
+
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v15/CLIC_o3_v15.xml"]
 geoservice.OutputLevel = INFO


### PR DESCRIPTION

Currently I get the error
```
CellIDSvc            INFO Taking the encoding string as specified in dd4hep constant: GlobalTrackerReadoutID
CellIDSvc            INFO LCTrackerCellID::_encoding will be set to system:5,side:-2,layer:6,module:11,sensor:8
AlgorithmManager    ERROR Algorithm of type TrackingCellIDEncodingSvc is unknown (No factory available).
AlgorithmManager    ERROR Unknown error -1342251347
```

I think it might be because `TrackingCellIDEncodingSvc` was added [here](https://github.com/key4hep/k4MarlinWrapper/commit/169af2703f6c696d1a3e97197999fa1bf84bb909) on September 13th. Then on  September the 28th, [this commit](https://github.com/key4hep/k4MarlinWrapper/commit/11efbbb527f8dcf9dec0529889fab4b08fad8071) seems to move it to a different namespace?