### PR TITLE
Add the edm4hep includes to allow compilation with clang

### DIFF
--- a/k4MarlinWrapper/src/components/GlobalConvertedObjectsMap.h
+++ b/k4MarlinWrapper/src/components/GlobalConvertedObjectsMap.h
@@ -21,20 +21,19 @@
 
 #include "k4EDM4hep2LcioConv/MappingUtils.h"
 
+#include "edm4hep/CalorimeterHit.h"
+#include "edm4hep/Cluster.h"
+#include "edm4hep/MCParticle.h"
+#include "edm4hep/ParticleID.h"
+#include "edm4hep/RawCalorimeterHit.h"
+#include "edm4hep/RawTimeSeries.h"
+#include "edm4hep/ReconstructedParticle.h"
+#include "edm4hep/SimCalorimeterHit.h"
+#include "edm4hep/SimTrackerHit.h"
 #include "edm4hep/Track.h"
 #include "edm4hep/TrackerHit.h"
 #include "edm4hep/TrackerHitPlane.h"
-#include "edm4hep/SimTrackerHit.h"
-#include "edm4hep/CalorimeterHit.h"
-#include "edm4hep/RawCalorimeterHit.h"
-#include "edm4hep/SimCalorimeterHit.h"
-#include "edm4hep/RawTimeSeries.h"
-#include "edm4hep/Cluster.h"
 #include "edm4hep/Vertex.h"
-#include "edm4hep/ReconstructedParticle.h"
-#include "edm4hep/MCParticle.h"
-#include "edm4hep/ParticleID.h"
-
 
 #include <string_view>
 

--- a/k4MarlinWrapper/src/components/GlobalConvertedObjectsMap.h
+++ b/k4MarlinWrapper/src/components/GlobalConvertedObjectsMap.h
@@ -21,6 +21,21 @@
 
 #include "k4EDM4hep2LcioConv/MappingUtils.h"
 
+#include "edm4hep/Track.h"
+#include "edm4hep/TrackerHit.h"
+#include "edm4hep/TrackerHitPlane.h"
+#include "edm4hep/SimTrackerHit.h"
+#include "edm4hep/CalorimeterHit.h"
+#include "edm4hep/RawCalorimeterHit.h"
+#include "edm4hep/SimCalorimeterHit.h"
+#include "edm4hep/RawTimeSeries.h"
+#include "edm4hep/Cluster.h"
+#include "edm4hep/Vertex.h"
+#include "edm4hep/ReconstructedParticle.h"
+#include "edm4hep/MCParticle.h"
+#include "edm4hep/ParticleID.h"
+
+
 #include <string_view>
 
 namespace EVENT {
@@ -38,22 +53,6 @@ namespace EVENT {
   class MCParticle;
   class ParticleID;
 }  // namespace EVENT
-
-namespace edm4hep {
-  class Track;
-  class TrackerHit;
-  class TrackerHitPlane;
-  class SimTrackerHit;
-  class CalorimeterHit;
-  class RawCalorimeterHit;
-  class SimCalorimeterHit;
-  class RawTimeSeries;
-  class Cluster;
-  class Vertex;
-  class ReconstructedParticle;
-  class MCParticle;
-  class ParticleID;
-}  // namespace edm4hep
 
 namespace k4MarlinWrapper {
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -22,20 +22,6 @@
 #include <EVENT/LCCollection.h>
 #include <Exceptions.h>
 
-#include <edm4hep/ClusterCollection.h>
-#include <edm4hep/Constants.h>
-#include <edm4hep/EventHeaderCollection.h>
-#include <edm4hep/MCParticleCollection.h>
-#include <edm4hep/ParticleIDCollection.h>
-#include <edm4hep/RawCalorimeterHitCollection.h>
-#include <edm4hep/RawTimeSeriesCollection.h>
-#include <edm4hep/ReconstructedParticleCollection.h>
-#include <edm4hep/SimCalorimeterHitCollection.h>
-#include <edm4hep/SimTrackerHitCollection.h>
-#include <edm4hep/TrackCollection.h>
-#include <edm4hep/TrackerHitPlaneCollection.h>
-#include <edm4hep/VertexCollection.h>
-
 #include "k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h"
 
 #include <k4FWCore/DataHandle.h>


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the edm4hep includes to allow compilation with clang, which currently doesn't compile due to incomplete classes

ENDRELEASENOTES

Possible related discussion about different behavior for gcc and clang:
https://stackoverflow.com/questions/22770318/incomplete-types-in-template-code

With this change I can compile both on gcc and clang. Previously all the classes had to be specified anyway so having the includes is not that much of a change.