### PR TITLE
Remove no longer necessary specification of input collections

### DIFF
--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -38,47 +38,12 @@ parseConstants(CONSTANTS)
 from Configurables import ToolSvc, Lcio2EDM4hepTool, EDM4hep2LcioTool
 
 
-# read = LcioEvent()
-# read.OutputLevel = WARNING
-# read.Files = ["ttbar.slcio"]
-# algList.append(read)
-
-
 from Configurables import k4DataSvc, PodioInput
 evtsvc = k4DataSvc('EventDataSvc')
 evtsvc.input = os.path.join('$TEST_DIR/inputFiles/', os.environ.get("INPUTFILE", "ttbar_edm4hep_frame.root"))
 
 
 inp = PodioInput('InputReader')
-inp.collections = [
-  'MCParticles',
-  'VertexBarrelCollection',
-  'VertexEndcapCollection',
-  'InnerTrackerBarrelCollection',
-  'OuterTrackerBarrelCollection',
-  'InnerTrackerEndcapCollection',
-  'OuterTrackerEndcapCollection',
-  'ECalEndcapCollection',
-  'ECalEndcapCollectionContributions',
-  'ECalBarrelCollection',
-  'ECalBarrelCollectionContributions',
-  'ECalPlugCollection',
-  'ECalPlugCollectionContributions',
-  'HCalBarrelCollection',
-  'HCalBarrelCollectionContributions',
-  'HCalEndcapCollection',
-  'HCalEndcapCollectionContributions',
-  'HCalRingCollection',
-  'HCalRingCollectionContributions',
-  'YokeBarrelCollection',
-  'YokeBarrelCollectionContributions',
-  'YokeEndcapCollection',
-  'YokeEndcapCollectionContributions',
-  'LumiCalCollection',
-  'LumiCalCollectionContributions',
-  'BeamCalCollection',
-  'BeamCalCollectionContributions',
-]
 inp.OutputLevel = DEBUG
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Cleanup the clic reconstruction from EDM4hep inputs example a bit.
  - Remove commented LCIO input
  - Remove explicit listing of input collections, which is no longer necessary after [k4FWCore#162](https://github.com/key4hep/k4FWCore/pull/162)

ENDRELEASENOTES
