### PR TITLE
Adapt the on-the-fly conversion to deal with reversed ParticleID relations

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -50,6 +50,7 @@ using RawCaloHitMap    = ObjMapT<lcio::RawCalorimeterHitImpl*, edm4hep::RawCalor
 using TPCHitMap        = ObjMapT<lcio::TPCHitImpl*, edm4hep::RawTimeSeries>;
 using RecoParticleMap  = ObjMapT<lcio::ReconstructedParticleImpl*, edm4hep::ReconstructedParticle>;
 using MCParticleMap    = ObjMapT<lcio::MCParticleImpl*, edm4hep::MCParticle>;
+using ParticleIDMap    = ObjMapT<lcio::ParticleIDImpl*, edm4hep::ParticleID>;
 
 struct CollectionPairMappings;
 
@@ -99,13 +100,16 @@ private:
   void convertReconstructedParticles(RecoParticleMap& recoparticles_vec, const std::string& e4h_coll_name,
                                      const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);
 
+  void convertParticleIDs(ParticleIDMap& pidMap, const std::string& e4h_coll_name, int32_t algoId);
+
   void convertMCParticles(MCParticleMap& mc_particles_vec, const std::string& e4h_coll_name,
                           const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);
 
   void convertEventHeader(const std::string& e4h_coll_name, lcio::LCEventImpl* lcio_event);
 
   void convertAdd(const std::string& e4h_coll_name, const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event,
-                  CollectionPairMappings& collection_pairs);
+                  CollectionPairMappings&                            collection_pairs,
+                  std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections);
 };
 
 #endif


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the on-the-fly EDM conversion deal with the reversed ParticleID relations and the related metadata

ENDRELEASENOTES

- [ ] Needs https://github.com/key4hep/EDM4hep/pull/268
- [ ] Needs  https://github.com/key4hep/k4EDM4hep2LcioConv/pull/51
- [ ] Tests for correct conversion of PIDs + metadata