### PR TITLE
Harmonize verbosities

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
@@ -65,7 +65,7 @@ public:
   virtual StatusCode initialize() override final;
 
 private:
-  std::string        m_verbosity = "MESSAGE";
+  std::string        m_verbosity = "ERROR";
   marlin::Processor* m_processor = nullptr;
 
   /// Load libraries specified by MARLIN_DLL environment variable

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -168,6 +168,24 @@ StatusCode MarlinProcessorWrapper::initialize() {
     }
   }
 
+  // Set m_verbosity from OutputLevel of the MarlinProcessorWrapper
+  MSG::Level outputLevel = msgLevel();
+  switch (outputLevel) {
+    case MSG::ERROR:
+      m_verbosity = "ERROR";
+      break;
+    case MSG::WARNING:
+      m_verbosity = "WARNING";
+      break;
+    case MSG::INFO:
+      m_verbosity = "MESSAGE";
+      break;
+    case MSG::DEBUG:
+      m_verbosity = "DEBUG";
+      break;
+  }
+
+  // pass m_verbosity to overwrite it if explicitly stated in wrapped parameters
   auto parameters = parseParameters(m_parameters, m_verbosity);
   if (instantiateProcessor(parameters, m_processorType).isFailure()) {
     return StatusCode::FAILURE;


### PR DESCRIPTION
BEGINRELEASENOTES
- By default use the `MarlinProcessorWrapper.OutputLevel` to set the verbosity of the wrapped Marlin processor.

ENDRELEASENOTES

It is still possible to overwrite the verbosity from the wrapped parameters. I also changed the default to `ERROR` (least output) this then also behaves as expected when even stricter Gaudi msg levels are choosen like `FATAL` or `ALWAYS`.

fixes: #175 