### PR TITLE
Convert event parameters from LCIO to EDM4hep

### DIFF
--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -130,6 +130,11 @@ namespace {
 }  // namespace
 
 StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
+  // Convert event parameters
+  // auto& frame = const_cast<podio::Frame&>(m_podioDataSvc->getEventFrame());
+  auto& frame = m_podioDataSvc->m_eventframe;
+  LCIO2EDM4hepConv::convertObjectParameters<lcio::LCEventImpl>(the_event, frame);
+
   // Convert Event Header outside the collections loop
   if (!collectionExist(edm4hep::EventHeaderName)) {
     registerCollection(edm4hep::EventHeaderName, LCIO2EDM4hepConv::createEventHeader(the_event));


### PR DESCRIPTION
BEGINRELEASENOTES
- Add lcio to edm4hep event parameter conversion

ENDRELEASENOTES

- [x] depends-on: https://github.com/key4hep/k4FWCore/pull/194
