### PR TITLE
Make sure that TrackerHitPlanes and TrackerHit3Ds get converted to LCIO

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -34,23 +34,23 @@
 // std
 #include <map>
 #include <string>
-#include <tuple>
 #include <vector>
 
 template <typename K, typename V> using ObjMapT = k4EDM4hep2LcioConv::VecMapT<K, V>;
 
-using TrackMap         = ObjMapT<lcio::TrackImpl*, edm4hep::Track>;
-using ClusterMap       = ObjMapT<lcio::ClusterImpl*, edm4hep::Cluster>;
-using VertexMap        = ObjMapT<lcio::VertexImpl*, edm4hep::Vertex>;
-using TrackerHitMap    = ObjMapT<lcio::TrackerHitImpl*, edm4hep::TrackerHit3D>;
-using SimTrackerHitMap = ObjMapT<lcio::SimTrackerHitImpl*, edm4hep::SimTrackerHit>;
-using CaloHitMap       = ObjMapT<lcio::CalorimeterHitImpl*, edm4hep::CalorimeterHit>;
-using SimCaloHitMap    = ObjMapT<lcio::SimCalorimeterHitImpl*, edm4hep::SimCalorimeterHit>;
-using RawCaloHitMap    = ObjMapT<lcio::RawCalorimeterHitImpl*, edm4hep::RawCalorimeterHit>;
-using TPCHitMap        = ObjMapT<lcio::TPCHitImpl*, edm4hep::RawTimeSeries>;
-using RecoParticleMap  = ObjMapT<lcio::ReconstructedParticleImpl*, edm4hep::ReconstructedParticle>;
-using MCParticleMap    = ObjMapT<lcio::MCParticleImpl*, edm4hep::MCParticle>;
-using ParticleIDMap    = ObjMapT<lcio::ParticleIDImpl*, edm4hep::ParticleID>;
+using TrackMap           = ObjMapT<lcio::TrackImpl*, edm4hep::Track>;
+using ClusterMap         = ObjMapT<lcio::ClusterImpl*, edm4hep::Cluster>;
+using VertexMap          = ObjMapT<lcio::VertexImpl*, edm4hep::Vertex>;
+using TrackerHitMap      = ObjMapT<lcio::TrackerHitImpl*, edm4hep::TrackerHit3D>;
+using TrackerHitPlaneMap = ObjMapT<lcio::TrackerHitPlaneImpl*, edm4hep::TrackerHitPlane>;
+using SimTrackerHitMap   = ObjMapT<lcio::SimTrackerHitImpl*, edm4hep::SimTrackerHit>;
+using CaloHitMap         = ObjMapT<lcio::CalorimeterHitImpl*, edm4hep::CalorimeterHit>;
+using SimCaloHitMap      = ObjMapT<lcio::SimCalorimeterHitImpl*, edm4hep::SimCalorimeterHit>;
+using RawCaloHitMap      = ObjMapT<lcio::RawCalorimeterHitImpl*, edm4hep::RawCalorimeterHit>;
+using TPCHitMap          = ObjMapT<lcio::TPCHitImpl*, edm4hep::RawTimeSeries>;
+using RecoParticleMap    = ObjMapT<lcio::ReconstructedParticleImpl*, edm4hep::ReconstructedParticle>;
+using MCParticleMap      = ObjMapT<lcio::MCParticleImpl*, edm4hep::MCParticle>;
+using ParticleIDMap      = ObjMapT<lcio::ParticleIDImpl*, edm4hep::ParticleID>;
 
 struct CollectionPairMappings;
 
@@ -75,6 +75,9 @@ private:
 
   void convertTrackerHits(TrackerHitMap& trackerhits_vec, const std::string& e4h_coll_name,
                           const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);
+
+  void convertTrackerHitPlanes(TrackerHitPlaneMap& trackerhits_vec, const std::string& e4h_coll_name,
+                               const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);
 
   void convertSimTrackerHits(SimTrackerHitMap& simtrackerhits_vec, const std::string& e4h_coll_name,
                              const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -290,7 +290,7 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
 
   if (fulltype == "edm4hep::Track") {
     convertTracks(collection_pairs.tracks, e4h_coll_name, lcio_coll_name, lcio_event);
-  } else if (fulltype == "edm4hep::TrackerHit") {
+  } else if (fulltype == "edm4hep::TrackerHit" || fulltype == "edm4hep::TrackerHit3D") {
     convertTrackerHits(collection_pairs.trackerHits, e4h_coll_name, lcio_coll_name, lcio_event);
   } else if (fulltype == "edm4hep::TrackerHitPlane") {
     convertTrackerHitPlanes(collection_pairs.trackerHitsPlane, e4h_coll_name, lcio_coll_name, lcio_event);
@@ -325,7 +325,7 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
   } else {
     warning() << "Error trying to convert requested " << fulltype << " with name " << e4h_coll_name << endmsg;
     warning() << "List of supported types: "
-              << "Track, TrackerHit, SimTrackerHit, "
+              << "Track, TrackerHit3D, TrackerHitPlane, SimTrackerHit, "
               << "Cluster, CalorimeterHit, RawCalorimeterHit, "
               << "SimCalorimeterHit, Vertex, ReconstructedParticle, "
               << "MCParticle." << endmsg;

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -96,7 +96,7 @@ void EDM4hep2LcioTool::convertTrackerHits(TrackerHitMap& trackerhits_vec, const 
   MetaDataHandle<std::string> cellIDStrHandle{trackerhits_handle, edm4hep::CellIDEncoding, Gaudi::DataHandle::Reader};
 
   auto conv_trackerhits =
-      EDM4hep2LCIOConv::convertTrackerHits(trackerhits_coll, cellIDStrHandle.get(), trackerhits_vec);
+      EDM4hep2LCIOConv::convertTrackerHits(trackerhits_coll, cellIDStrHandle.get(""), trackerhits_vec);
 
   // Add all trackerhits to event
   lcio_event->addCollection(conv_trackerhits.release(), lcio_coll_name);
@@ -116,7 +116,7 @@ void EDM4hep2LcioTool::convertTrackerHitPlanes(TrackerHitPlaneMap& trackerhits_v
   MetaDataHandle<std::string> cellIDStrHandle{trackerhits_handle, edm4hep::CellIDEncoding, Gaudi::DataHandle::Reader};
 
   auto conv_trackerhits =
-      EDM4hep2LCIOConv::convertTrackerHitPlanes(trackerhits_coll, cellIDStrHandle.get(), trackerhits_vec);
+      EDM4hep2LCIOConv::convertTrackerHitPlanes(trackerhits_coll, cellIDStrHandle.get(""), trackerhits_vec);
 
   // Add all trackerhits to event
   lcio_event->addCollection(conv_trackerhits.release(), lcio_coll_name);

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -35,18 +35,19 @@ using namespace k4MarlinWrapper;
 using GlobalMapWrapper = AnyDataWrapper<GlobalConvertedObjectsMap>;
 
 struct CollectionPairMappings {
-  TrackMap         tracks{};
-  TrackerHitMap    trackerHits{};
-  SimTrackerHitMap simTrackerHits{};
-  CaloHitMap       caloHits{};
-  RawCaloHitMap    rawCaloHits{};
-  SimCaloHitMap    simCaloHits{};
-  TPCHitMap        tpcHits{};
-  ClusterMap       clusters{};
-  VertexMap        vertices{};
-  RecoParticleMap  recoParticles{};
-  MCParticleMap    mcParticles{};
-  ParticleIDMap    particleIDs{};
+  TrackMap           tracks{};
+  TrackerHitMap      trackerHits{};
+  TrackerHitPlaneMap trackerHitsPlane{};
+  SimTrackerHitMap   simTrackerHits{};
+  CaloHitMap         caloHits{};
+  RawCaloHitMap      rawCaloHits{};
+  SimCaloHitMap      simCaloHits{};
+  TPCHitMap          tpcHits{};
+  ClusterMap         clusters{};
+  VertexMap          vertices{};
+  RecoParticleMap    recoParticles{};
+  MCParticleMap      mcParticles{};
+  ParticleIDMap      particleIDs{};
 };
 
 EDM4hep2LcioTool::EDM4hep2LcioTool(const std::string& type, const std::string& name, const IInterface* parent)
@@ -105,6 +106,20 @@ void EDM4hep2LcioTool::convertParticleIDs(ParticleIDMap& pidMap, const std::stri
   DataHandle<edm4hep::ParticleIDCollection> pidHandle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
 
   EDM4hep2LCIOConv::convertParticleIDs(pidHandle.get(), pidMap, algoId);
+}
+
+void EDM4hep2LcioTool::convertTrackerHitPlanes(TrackerHitPlaneMap& trackerhits_vec, const std::string& e4h_coll_name,
+                                               const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
+  DataHandle<edm4hep::TrackerHitPlaneCollection> trackerhits_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  const auto                                     trackerhits_coll = trackerhits_handle.get();
+
+  MetaDataHandle<std::string> cellIDStrHandle{trackerhits_handle, edm4hep::CellIDEncoding, Gaudi::DataHandle::Reader};
+
+  auto conv_trackerhits =
+      EDM4hep2LCIOConv::convertTrackerHitPlanes(trackerhits_coll, cellIDStrHandle.get(), trackerhits_vec);
+
+  // Add all trackerhits to event
+  lcio_event->addCollection(conv_trackerhits.release(), lcio_coll_name);
 }
 
 // Convert EDM4hep SimTrackerHits to LCIO
@@ -277,6 +292,8 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
     convertTracks(collection_pairs.tracks, e4h_coll_name, lcio_coll_name, lcio_event);
   } else if (fulltype == "edm4hep::TrackerHit") {
     convertTrackerHits(collection_pairs.trackerHits, e4h_coll_name, lcio_coll_name, lcio_event);
+  } else if (fulltype == "edm4hep::TrackerHitPlane") {
+    convertTrackerHitPlanes(collection_pairs.trackerHitsPlane, e4h_coll_name, lcio_coll_name, lcio_event);
   } else if (fulltype == "edm4hep::SimTrackerHit") {
     convertSimTrackerHits(collection_pairs.simTrackerHits, e4h_coll_name, lcio_coll_name, lcio_event);
   } else if (fulltype == "edm4hep::CalorimeterHit") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to convert `TrackerHitPlane` and `TrackerHit3D` from EDM4hep to LCIO

ENDRELEASENOTES

The necessary functionality was introduced in key4hep/k4EDM4hep2LcioConv#42 but apparently never added here until now.

This should fix errors that we currently see:
```
ToolSvc.InputCo...WARNING List of supported types: Track, TrackerHit, SimTrackerHit, Cluster, CalorimeterHit, RawCalorimeterHit, SimCalorimeterHit, Vertex, ReconstructedParticle, MCParticle.
ToolSvc.InputCo...WARNING Error trying to convert requested edm4hep::TrackerHitPlane with name InnerTrackerBarrelHits
```
