### PR TITLE
Use latest release instead of nightlies in tutorial.

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
@@ -22,7 +22,7 @@ It is possible to run the [C Event Display (CED)](https://github.com/iLCSoft/CED
 
 ## Setting up an environment
 
-The following steps have been tested with the Key4hep nightly builds release which can be setup using
+The following steps have been tested with the latest Key4hep release which can be setup using
 ```bash
 source /cvmfs/sw.hsf.org/key4hep/setup.sh
 ```

--- a/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
@@ -24,7 +24,7 @@ It is possible to run the [C Event Display (CED)](https://github.com/iLCSoft/CED
 
 The following steps have been tested with the Key4hep nightly builds release which can be setup using
 ```bash
-source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
 ```
 
 To get the CLIC detector description we clone the `CLICPerformance` repository


### PR DESCRIPTION
Ensure all tutorials are using the latest release instead of nightlies.

Fixes https://github.com/key4hep/key4hep-tutorials/issues/14.