### PR TITLE
Bump the minimum version of EDM4hep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ include(GNUInstallDirs)
 find_package(Gaudi REQUIRED)
 find_package(LCIO REQUIRED)
 find_package(Marlin REQUIRED)
-find_package(EDM4HEP 0.10.1 REQUIRED)
+find_package(EDM4HEP 0.99 REQUIRED)
 find_package(k4FWCore REQUIRED)
 find_package(k4EDM4hep2LcioConv REQUIRED)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum required version of EDM4hep to 0.99

ENDRELEASENOTES
