### PR TITLE
Move Associations to Links

### DIFF
--- a/test/src/MCRecoLinkChecker.cc
+++ b/test/src/MCRecoLinkChecker.cc
@@ -48,8 +48,8 @@ StatusCode MCRecoLinkChecker::execute(const EventContext&) const {
       return StatusCode::FAILURE;
     }
 
-    if (!(relation.getSim() == mc)) {
-      auto relMC = relation.getSim();
+    if (!(relation.getTo() == mc)) {
+      auto relMC = relation.getTo();
       error() << "Relation " << i
               << " does not point to the correct MCParticle (expected: " << mc.getObjectID().collectionID << "|"
               << mc.getObjectID().index << ", actual: " << relMC.getObjectID().collectionID << "|"
@@ -57,8 +57,8 @@ StatusCode MCRecoLinkChecker::execute(const EventContext&) const {
       return StatusCode::FAILURE;
     }
 
-    if (!(relation.getRec() == reco)) {
-      auto relRec = relation.getRec();
+    if (!(relation.getFrom() == reco)) {
+      auto relRec = relation.getFrom();
       error() << "Relation " << i
               << " does not point to the correct RecoParticle (expected: " << reco.getObjectID().collectionID << "|"
               << reco.getObjectID().index << ", actual: " << relRec.getObjectID().collectionID << "|"

--- a/test/src/MCRecoLinkChecker.h
+++ b/test/src/MCRecoLinkChecker.h
@@ -20,7 +20,7 @@
 #define K4MARLINWRAPPER_TEST_MCRECOLINKCHECKER_H
 
 #include "edm4hep/MCParticleCollection.h"
-#include "edm4hep/MCRecoParticleAssociationCollection.h"
+#include "edm4hep/RecoMCParticleLinkCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 
 #include "k4FWCore/DataHandle.h"
@@ -36,7 +36,7 @@ public:
   StatusCode execute(const EventContext&) const;
 
 private:
-  mutable DataHandle<edm4hep::MCRecoParticleAssociationCollection> m_relationCollHandle{
+  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_relationCollHandle{
       "MCRecoTruthLinks", Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::MCParticleCollection> m_mcCollHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_recoCollHandle{"RecoParticles",

--- a/test/src/MCRecoLinkChecker.h
+++ b/test/src/MCRecoLinkChecker.h
@@ -36,8 +36,8 @@ public:
   StatusCode execute(const EventContext&) const;
 
 private:
-  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_relationCollHandle{
-      "MCRecoTruthLinks", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_relationCollHandle{"MCRecoTruthLinks",
+                                                                                 Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::MCParticleCollection> m_mcCollHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_recoCollHandle{"RecoParticles",
                                                                                 Gaudi::DataHandle::Reader, this};


### PR DESCRIPTION
see https://github.com/key4hep/EDM4hep/pull/341

BEGINRELEASENOTES
- Move Associations to Links

ENDRELEASENOTES

I think it's not fully transparent because with my local setup I can't compile this repository without these changes.