### PR TITLE
Use Gaudi__Sequencer instead of the Sequencer coming from GaudiAlg

### DIFF
--- a/test/gaudi_opts/clicReconstruction_mt.py
+++ b/test/gaudi_opts/clicReconstruction_mt.py
@@ -21,7 +21,8 @@ import os
 from Gaudi.Configuration import *
 
 # Parallel stuff
-from Configurables import (HiveWhiteBoard, HiveSlimEventLoopMgr, AvalancheSchedulerSvc, GaudiSequencer)
+from Configurables import (HiveWhiteBoard, HiveSlimEventLoopMgr, AvalancheSchedulerSvc, Gaudi__Sequencer as Sequencer)
+
 
 evtslots = 4
 cardinality = 1

--- a/test/gaudi_opts/clicReconstruction_mt.py
+++ b/test/gaudi_opts/clicReconstruction_mt.py
@@ -1463,7 +1463,7 @@ for algo in algList:
     algo.Cardinality = cardinality
     algo.OutputLevel = DEBUG
 
-seq = GaudiSequencer(
+seq = Sequencer(
     "createViewSeq",
     Members=algList,
     Sequential=True,


### PR DESCRIPTION
BEGINRELEASENOTES
- Use Gaudi__Sequencer instead of the Sequencer coming from GaudiAlg

ENDRELEASENOTES

This should fix CI. It seems that from time to time the CLIC reconstruction crashes on Ubuntu...