### PR TITLE
Retrieve unique_ptrs for collections produced by functional algorithms

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -292,12 +292,10 @@ podio::CollectionBase* EDM4hep2LcioTool::getEDM4hepCollection(const std::string&
   // std::shared_ptr but this has been removed in k4FWCore so it can be deleted
   // at some point
   auto uptr = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(p);
-  AnyDataWrapper<std::shared_ptr<podio::CollectionBase>>* sptr = nullptr;
-  if (!uptr) {
-    sptr = dynamic_cast<AnyDataWrapper<std::shared_ptr<podio::CollectionBase>>*>(p);
-  } else {
+  if (uptr) {
     return uptr->getData().get();
   }
+  auto sptr = dynamic_cast<AnyDataWrapper<std::shared_ptr<podio::CollectionBase>>*>(p);
   if (sptr) {
     return sptr->getData().get();
   }

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -277,8 +277,8 @@ void EDM4hep2LcioTool::convertEventHeader(const std::string& e4h_coll_name, lcio
 }
 
 podio::CollectionBase* EDM4hep2LcioTool::getEDM4hepCollection(const std::string& collName) const {
-  DataObject*            p;
-  auto                   sc = m_podioDataSvc->retrieveObject(collName, p);
+  DataObject* p;
+  auto        sc = m_podioDataSvc->retrieveObject(collName, p);
   if (sc.isFailure()) {
     throw GaudiException("Collection not found", name(), StatusCode::FAILURE);
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Retrieve unique_ptrs for collections produced by functional algorithms. Needed after https://github.com/key4hep/k4FWCore/pull/250. It should also be able to handle the case for the previous approach with `std::shared_ptr`.

ENDRELEASENOTES