### PR TITLE
Only add an OutputLevel if Verbosity is set

### DIFF
--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -221,7 +221,9 @@ def verbosityTranslator(marlinLogLevel):
 def convertParameters(params, proc, globParams, constants):
   """ convert json of parameters to gaudi """
   lines = []
-  lines.append("%s.OutputLevel = %s" % (proc.replace(".", "_"), verbosityTranslator(globParams.get("Verbosity"))))
+  if "Verbosity" in params:
+    lines.append("%s.OutputLevel = %s" % (proc.replace(".", "_"), verbosityTranslator(params["Verbosity"])))
+
   lines.append("%s.ProcessorType = \"%s\"" % (proc.replace(".", "_"), params.get("type")))
   lines.append("%s.Parameters = {" % proc.replace(".", "_"))
   for para in sorted(params):


### PR DESCRIPTION
Unlike Marlin, Gaudi doesn't override OutputLevels of Algorithms if they have been manually set in the options file. Hence, if we populate all wrapped processor OutputLevels it will require changing all of them manually afterwards if we want the global OutputLevel that is set in the AlgorithmMgr to apply.


BEGINRELEASENOTES
- Only set the `OutputLevel` for converted MarlinProcessors if `Verbosity` was set in the original XML steering file

ENDRELEASENOTES
