### PR TITLE
Multiple minor fixes

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/LCEventWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/LCEventWrapper.h
@@ -30,8 +30,6 @@ class LCEventWrapper : public DataObject {
 public:
   LCEventWrapper(std::unique_ptr<EVENT::LCEvent>&& theEvent) : m_event(std::move(theEvent)) {}
 
-  ~LCEventWrapper() = default;
-
   EVENT::LCEvent* getEvent() const { return m_event.get(); }
 
 private:

--- a/k4MarlinWrapper/k4MarlinWrapper/LcioEventAlgo.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/LcioEventAlgo.h
@@ -26,19 +26,17 @@
  */
 
 #include <Gaudi/Algorithm.h>
-#include <GaudiKernel/IEventProcessor.h>
+#include <Gaudi/Property.h>
 
-#include <EVENT/LCIO.h>
-#include <MT/LCReader.h>
-
-#include "k4MarlinWrapper/LCEventWrapper.h"
+namespace MT {
+  class LCReader;
+}
 
 class LcioEvent : public Gaudi::Algorithm {
 public:
   explicit LcioEvent(const std::string& name, ISvcLocator* pSL);
-  virtual ~LcioEvent() = default;
-  virtual StatusCode initialize() override final;
-  virtual StatusCode execute(const EventContext&) const override;
+  StatusCode initialize() override final;
+  StatusCode execute(const EventContext&) const override;
 
 private:
   Gaudi::Property<std::vector<std::string>> m_fileNames{this, "Files", {}};

--- a/k4MarlinWrapper/k4MarlinWrapper/LcioEventAlgo.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/LcioEventAlgo.h
@@ -35,13 +35,13 @@ namespace MT {
 class LcioEvent : public Gaudi::Algorithm {
 public:
   explicit LcioEvent(const std::string& name, ISvcLocator* pSL);
-  StatusCode initialize() override final;
-  StatusCode execute(const EventContext&) const override;
+  StatusCode initialize() final;
+  StatusCode execute(const EventContext&) const final;
 
 private:
   Gaudi::Property<std::vector<std::string>> m_fileNames{this, "Files", {}};
   MT::LCReader*                             m_reader = nullptr;
-  bool                                      isReEntrant() const override { return false; }
+  bool                                      isReEntrant() const final { return false; }
 };
 
 #endif

--- a/k4MarlinWrapper/k4MarlinWrapper/LcioEventOutput.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/LcioEventOutput.h
@@ -42,9 +42,9 @@ namespace MT {
 class LcioEventOutput : public Gaudi::Algorithm {
 public:
   explicit LcioEventOutput(const std::string& name, ISvcLocator* pSL);
-  StatusCode initialize() override final;
+  StatusCode initialize() final;
   StatusCode execute(const EventContext&) const final;
-  StatusCode finalize() override final;
+  StatusCode finalize() final;
 
 private:
   MT::LCWriter* m_writer = nullptr;

--- a/k4MarlinWrapper/k4MarlinWrapper/LcioEventOutput.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/LcioEventOutput.h
@@ -24,25 +24,27 @@
 // LCEventOutput: Write out LCIO events using MT writer from LCIO
 ////////////////////////////////////////////
 
-#include <iostream>
-
 #include <Gaudi/Algorithm.h>
+#include <Gaudi/Property.h>
 
 #include <EVENT/LCIO.h>
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCEventImpl.h>
-#include <MT/LCWriter.h>
 #include <lcio.h>
 
-#include "k4MarlinWrapper/LCEventWrapper.h"
+#include <string>
+#include <vector>
+
+namespace MT {
+  class LCWriter;
+}
 
 class LcioEventOutput : public Gaudi::Algorithm {
 public:
   explicit LcioEventOutput(const std::string& name, ISvcLocator* pSL);
-  virtual ~LcioEventOutput() = default;
-  virtual StatusCode initialize() override final;
-  virtual StatusCode execute(const EventContext&) const final;
-  virtual StatusCode finalize() override final;
+  StatusCode initialize() override final;
+  StatusCode execute(const EventContext&) const final;
+  StatusCode finalize() override final;
 
 private:
   MT::LCWriter* m_writer = nullptr;

--- a/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
@@ -19,22 +19,18 @@
 #ifndef K4MARLINWRAPPER_MARLINPROCESSORWRAPPER_H
 #define K4MARLINWRAPPER_MARLINPROCESSORWRAPPER_H
 
-// std
 #include <stack>
 #include <string>
 
-// Gaudi
 #include <Gaudi/Algorithm.h>
 #include <GaudiKernel/IEventProcessor.h>
 #include <GaudiKernel/IRndmEngine.h>
 #include <GaudiKernel/MsgStream.h>
 #include <GaudiKernel/ToolHandle.h>
 
-// LCIO
 #include <EVENT/LCEvent.h>
 #include <EVENT/LCRunHeader.h>
 
-// Marlin
 #include <marlin/EventModifier.h>
 #include <marlin/Exceptions.h>
 #include <marlin/Global.h>
@@ -42,10 +38,8 @@
 #include <marlin/ProcessorMgr.h>
 #include <marlin/StringParameters.h>
 
-// ROOT
 #include <TSystem.h>
 
-// k4MarlinWrapper
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
 namespace marlin {
@@ -56,10 +50,9 @@ namespace marlin {
 class MarlinProcessorWrapper : public Gaudi::Algorithm {
 public:
   explicit MarlinProcessorWrapper(const std::string& name, ISvcLocator* pSL);
-  virtual ~MarlinProcessorWrapper() = default;
-  virtual StatusCode execute(const EventContext&) const override final;
-  virtual StatusCode finalize() override final;
-  virtual StatusCode initialize() override final;
+  StatusCode execute(const EventContext&) const override final;
+  StatusCode finalize() override final;
+  StatusCode initialize() override final;
 
 private:
   std::string                m_verbosity = "ERROR";

--- a/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
@@ -50,9 +50,9 @@ namespace marlin {
 class MarlinProcessorWrapper : public Gaudi::Algorithm {
 public:
   explicit MarlinProcessorWrapper(const std::string& name, ISvcLocator* pSL);
-  StatusCode execute(const EventContext&) const override final;
-  StatusCode finalize() override final;
-  StatusCode initialize() override final;
+  StatusCode execute(const EventContext&) const final;
+  StatusCode finalize() final;
+  StatusCode initialize() final;
 
 private:
   std::string                m_verbosity = "ERROR";
@@ -78,7 +78,7 @@ private:
 
   static std::stack<marlin::Processor*>& ProcessorStack();
 
-  bool isReEntrant() const override { return false; }
+  bool isReEntrant() const final { return false; }
 };
 
 std::stack<marlin::Processor*>& MarlinProcessorWrapper::ProcessorStack() {

--- a/k4MarlinWrapper/k4MarlinWrapper/TrackingCellIDEncodingSvc.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/TrackingCellIDEncodingSvc.h
@@ -19,10 +19,8 @@
 #ifndef CELLIDSVC_H
 #define CELLIDSVC_H
 
+#include <Gaudi/Property.h>
 #include <GaudiKernel/Service.h>
-
-//LCIO Includes
-#include <UTIL/LCTrackerConf.h>
 
 #include <string>
 
@@ -32,7 +30,6 @@ class TrackingCellIDEncodingSvc : public extends<Service, IService> {
 public:
   TrackingCellIDEncodingSvc(const std::string& name, ISvcLocator* svc);
 
-  ~TrackingCellIDEncodingSvc();
   StatusCode initialize() final;
   StatusCode finalize() final;
 

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -53,10 +53,10 @@ struct CollectionPairMappings;
 class EDM4hep2LcioTool : public AlgTool, virtual public IEDMConverter {
 public:
   EDM4hep2LcioTool(const std::string& type, const std::string& name, const IInterface* parent);
-  StatusCode initialize() override;
-  StatusCode finalize() override;
+  StatusCode initialize() final;
+  StatusCode finalize() final;
 
-  StatusCode convertCollections(lcio::LCEventImpl* lcio_event) override;
+  StatusCode convertCollections(lcio::LCEventImpl* lcio_event) final;
 
 private:
   Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -19,20 +19,15 @@
 #ifndef K4MARLINWRAPPER_EDM4HEP2LCIO_H
 #define K4MARLINWRAPPER_EDM4HEP2LCIO_H
 
-// k4MarlinWrapper
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
-// FWCore
 #include <k4FWCore/PodioDataSvc.h>
 
-//k4EDM4hep2LcioConv
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h"
 
-// GAUDI
 #include <Gaudi/Property.h>
 #include <GaudiKernel/AlgTool.h>
 
-// std
 #include <map>
 #include <string>
 #include <vector>
@@ -58,11 +53,11 @@ struct CollectionPairMappings;
 class EDM4hep2LcioTool : public AlgTool, virtual public IEDMConverter {
 public:
   EDM4hep2LcioTool(const std::string& type, const std::string& name, const IInterface* parent);
-  virtual ~EDM4hep2LcioTool();
-  virtual StatusCode initialize();
-  virtual StatusCode finalize();
+  ~EDM4hep2LcioTool() override = default;
+  StatusCode initialize() override;
+  StatusCode finalize() override;
 
-  StatusCode convertCollections(lcio::LCEventImpl* lcio_event);
+  StatusCode convertCollections(lcio::LCEventImpl* lcio_event) override;
 
 private:
   Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -21,8 +21,6 @@
 
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
-#include <k4FWCore/PodioDataSvc.h>
-
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h"
 
 #include <Gaudi/Property.h>
@@ -31,6 +29,8 @@
 #include <map>
 #include <string>
 #include <vector>
+
+class PodioDataSvc;
 
 template <typename K, typename V> using ObjMapT = k4EDM4hep2LcioConv::VecMapT<K, V>;
 
@@ -53,7 +53,6 @@ struct CollectionPairMappings;
 class EDM4hep2LcioTool : public AlgTool, virtual public IEDMConverter {
 public:
   EDM4hep2LcioTool(const std::string& type, const std::string& name, const IInterface* parent);
-  ~EDM4hep2LcioTool() override = default;
   StatusCode initialize() override;
   StatusCode finalize() override;
 

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -19,14 +19,9 @@
 #ifndef K4MARLINWRAPPER_LCIO2EDM4HEP_H
 #define K4MARLINWRAPPER_LCIO2EDM4HEP_H
 
-// GAUDI
 #include <Gaudi/Property.h>
 #include <GaudiKernel/AlgTool.h>
 
-// k4FWCore
-#include <k4FWCore/PodioDataSvc.h>
-
-// Converter Interface
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
 #include <lcio.h>
@@ -43,10 +38,11 @@ namespace EVENT {
   class LCCollection;
 }
 
+class PodioDataSvc;
+
 class Lcio2EDM4hepTool : public AlgTool, virtual public IEDMConverter {
 public:
   Lcio2EDM4hepTool(const std::string& type, const std::string& name, const IInterface* parent);
-  ~Lcio2EDM4hepTool() override = default;
   StatusCode initialize() final;
   StatusCode finalize() final;
 

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -52,7 +52,7 @@ public:
   // - Convert associated collections from LCRelation for existing EDM4hep relations
   // - Converted collections are put into TES
   // **********************************
-  StatusCode convertCollections(lcio::LCEventImpl* lcio_event) override;
+  StatusCode convertCollections(lcio::LCEventImpl* lcio_event) final;
 
 private:
   Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -46,7 +46,7 @@ namespace EVENT {
 class Lcio2EDM4hepTool : public AlgTool, virtual public IEDMConverter {
 public:
   Lcio2EDM4hepTool(const std::string& type, const std::string& name, const IInterface* parent);
-  virtual ~Lcio2EDM4hepTool();
+  ~Lcio2EDM4hepTool() override = default;
   StatusCode initialize() final;
   StatusCode finalize() final;
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -23,6 +23,7 @@
 
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"
+#include "k4FWCore/PodioDataSvc.h"
 
 #include "GaudiKernel/AnyDataWrapper.h"
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -53,8 +53,6 @@ EDM4hep2LcioTool::EDM4hep2LcioTool(const std::string& type, const std::string& n
   declareInterface<IEDMConverter>(this);
 }
 
-EDM4hep2LcioTool::~EDM4hep2LcioTool() { ; }
-
 StatusCode EDM4hep2LcioTool::initialize() {
   StatusCode sc  = m_eventDataSvc.retrieve();
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -40,6 +40,11 @@ using namespace k4MarlinWrapper;
 Lcio2EDM4hepTool::Lcio2EDM4hepTool(const std::string& type, const std::string& name, const IInterface* parent)
     : AlgTool(type, name, parent), m_eds("EventDataSvc", "Lcio2EDM4hepTool") {
   declareInterface<IEDMConverter>(this);
+
+  StatusCode sc = m_eds.retrieve();
+  if (sc.isFailure()) {
+    error() << "Could not retrieve EventDataSvc" << endmsg;
+  }
 }
 
 StatusCode Lcio2EDM4hepTool::initialize() {

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -49,7 +49,7 @@ Lcio2EDM4hepTool::Lcio2EDM4hepTool(const std::string& type, const std::string& n
 
 StatusCode Lcio2EDM4hepTool::initialize() {
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eds.get());
-  if (nullptr == m_podioDataSvc)
+  if (!m_podioDataSvc)
     return StatusCode::FAILURE;
 
   return AlgTool::initialize();
@@ -74,7 +74,7 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
 void Lcio2EDM4hepTool::registerCollection(
     std::tuple<const std::string&, std::unique_ptr<podio::CollectionBase>> namedColl, EVENT::LCCollection* lcioColl) {
   auto& [name, e4hColl] = namedColl;
-  if (e4hColl == nullptr) {
+  if (!e4hColl) {
     error() << "Could not convert collection " << name << endmsg;
     return;
   }

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -28,6 +28,7 @@
 
 #include <k4FWCore/DataHandle.h>
 #include <k4FWCore/MetaDataHandle.h>
+#include <k4FWCore/PodioDataSvc.h>
 
 #include "GaudiKernel/AnyDataWrapper.h"
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -40,11 +40,7 @@ using namespace k4MarlinWrapper;
 Lcio2EDM4hepTool::Lcio2EDM4hepTool(const std::string& type, const std::string& name, const IInterface* parent)
     : AlgTool(type, name, parent), m_eds("EventDataSvc", "Lcio2EDM4hepTool") {
   declareInterface<IEDMConverter>(this);
-
-  StatusCode sc = m_eds.retrieve();
 }
-
-Lcio2EDM4hepTool::~Lcio2EDM4hepTool() { ; }
 
 StatusCode Lcio2EDM4hepTool::initialize() {
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eds.get());
@@ -198,7 +194,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
           error() << "Could not convert collection " << lcioName << " (type: " << lcio_coll_type_str << ")" << endmsg;
         }
       }
-    } catch (const lcio::DataNotAvailableException& ex) {
+    } catch (const lcio::DataNotAvailableException&) {
       warning() << "LCIO Collection " << lcioName << " not found in the event, skipping conversion to EDM4hep"
                 << endmsg;
       continue;

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -41,7 +41,7 @@ StatusCode LcioEvent::initialize() {
 StatusCode LcioEvent::execute(const EventContext&) const {
   auto theEvent = m_reader->readNextEvent(EVENT::LCIO::UPDATE);
 
-  if (theEvent == nullptr) {
+  if (!theEvent) {
     // Store flag to indicate there was NOT a LCEvent
     auto             pStatus  = std::make_unique<LCEventWrapperStatus>(false);
     const StatusCode scStatus = eventSvc()->registerObject("/Event/LCEventStatus", pStatus.release());

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -17,9 +17,19 @@
  * limitations under the License.
  */
 
-#include "k4MarlinWrapper/LcioEventAlgo.h"
+#include <GaudiKernel/IEventProcessor.h>
+
 #include "k4MarlinWrapper/LCEventWrapper.h"
-#include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
+#include "k4MarlinWrapper/LcioEventAlgo.h"
+
+#include "marlin/Global.h"
+#include "marlin/StringParameters.h"
+
+#include <EVENT/LCIO.h>
+#include <MT/LCReader.h>
+
+#include <memory>
+#include <string>
 
 DECLARE_COMPONENT(LcioEvent)
 

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -52,10 +52,10 @@ StatusCode LcioEvent::execute(const EventContext&) const {
       return scStatus;
     }
 
-    IEventProcessor* evt = nullptr;
-    if (service("ApplicationMgr", evt, true).isSuccess()) {
-      evt->stopRun().ignore();
-      evt->release();
+    auto svc = service<IEventProcessor>("ApplicationMgr");
+    if (svc) {
+      svc->stopRun().ignore();
+      svc->release();
     } else {
       abort();
     }

--- a/k4MarlinWrapper/src/components/LcioEventOutput.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventOutput.cpp
@@ -17,7 +17,13 @@
  * limitations under the License.
  */
 
+#include <MT/LCWriter.h>
+
+#include "k4MarlinWrapper/LCEventWrapper.h"
 #include "k4MarlinWrapper/LcioEventOutput.h"
+
+#include <string>
+#include <vector>
 
 DECLARE_COMPONENT(LcioEventOutput)
 

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -131,12 +131,12 @@ std::shared_ptr<marlin::StringParameters> MarlinProcessorWrapper::parseParameter
 StatusCode MarlinProcessorWrapper::instantiateProcessor(std::shared_ptr<marlin::StringParameters>& parameters,
                                                         Gaudi::Property<std::string>&              processorTypeStr) {
   auto processorType = marlin::ProcessorMgr::instance()->getProcessor(processorTypeStr);
-  if (not processorType) {
+  if (!processorType) {
     error() << " Failed to instantiate " << name() << " because processor type could not be determined" << endmsg;
     return StatusCode::FAILURE;
   }
   m_processor = processorType->newProcessor();
-  if (not m_processor) {
+  if (!m_processor) {
     error() << " Failed to instantiate " << name() << endmsg;
     return StatusCode::FAILURE;
   }
@@ -215,7 +215,7 @@ StatusCode MarlinProcessorWrapper::execute(const EventContext&) const {
   StatusCode  scStatus = eventSvc()->retrieveObject("/Event/LCEventStatus", pStatus);
   if (scStatus.isSuccess()) {
     bool hasLCEvent = static_cast<LCEventWrapperStatus*>(pStatus)->hasLCEvent;
-    if (not hasLCEvent) {
+    if (!hasLCEvent) {
       warning() << "LCIO Event reading returned nullptr, so MarlinProcessorWrapper won't execute" << endmsg;
       return StatusCode::SUCCESS;
     }

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -22,6 +22,10 @@
 #include "k4MarlinWrapper/LCEventWrapper.h"
 #include "k4MarlinWrapper/util/k4MarlinWrapperUtil.h"
 
+#include <map>
+#include <string>
+#include <vector>
+
 DECLARE_COMPONENT(MarlinProcessorWrapper)
 
 MarlinProcessorWrapper::MarlinProcessorWrapper(const std::string& name, ISvcLocator* pSL)

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -297,10 +297,10 @@ StatusCode MarlinProcessorWrapper::execute(const EventContext&) const {
     error() << e.what() << endmsg;
 
     // Send stop to EventProcessor
-    IEventProcessor* evt = nullptr;
-    if (service("ApplicationMgr", evt, true).isSuccess()) {
-      evt->stopRun().ignore();
-      evt->release();
+    auto svc = service<IEventProcessor>("ApplicationMgr");
+    if (svc) {
+      svc->stopRun().ignore();
+      svc->release();
     } else {
       abort();
     }

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -81,7 +81,7 @@ StatusCode MarlinProcessorWrapper::loadProcessorLibraries() const {
   // Load all libraries from the marlin_dll
   info() << "looking for marlindll" << endmsg;
   const char* const marlin_dll = getenv("MARLIN_DLL");
-  if (marlin_dll == nullptr) {
+  if (!marlin_dll) {
     warning() << "MARLIN_DLL not set, not loading any processors " << endmsg;
   } else {
     info() << "Found marlin_dll " << marlin_dll << endmsg;

--- a/k4MarlinWrapper/src/components/TrackingCellIDEncodingSvc.cpp
+++ b/k4MarlinWrapper/src/components/TrackingCellIDEncodingSvc.cpp
@@ -16,9 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <UTIL/LCTrackerConf.h>
+
 #include "k4MarlinWrapper/TrackingCellIDEncodingSvc.h"
 
-// k4fwcore
 #include <k4Interface/IGeoSvc.h>
 
 #include <GaudiKernel/MsgStream.h>
@@ -27,8 +29,6 @@ DECLARE_COMPONENT(TrackingCellIDEncodingSvc);
 
 TrackingCellIDEncodingSvc::TrackingCellIDEncodingSvc(const std::string& name, ISvcLocator* svc)
     : base_class(name, svc) {}
-
-TrackingCellIDEncodingSvc::~TrackingCellIDEncodingSvc() {}
 
 StatusCode TrackingCellIDEncodingSvc::initialize() {
   try {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,28 +98,15 @@ add_test( event_header_conversion bash -c "k4run ${CMAKE_CURRENT_SOURCE_DIR}/gau
 
 ExternalData_Add_Target(marlinwrapper_tests)
 
-set_tests_properties (
-    simple_processors
-    simple_processors2
-    clicRec
-    converter_constants
-    all_events_bounds
-    over_total_events
-    same_num_io
-    clicRec_lcio_mt
-    clicRec_edm4hep_input
-    clic_geo_test
-    global_converter_maps
-    event_header_conversion
-    link_conversion_edm4hep_to_lcio
-  PROPERTIES
-    ENVIRONMENT "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH};EXAMPLE_DIR=${PROJECT_SOURCE_DIR}/k4MarlinWrapper/examples;MARLIN_DLL=$ENV{MARLIN_DLL}:${CMAKE_CURRENT_BINARY_DIR}/libMarlinTestProcessors.so"
-    )
+get_property(test_names DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY TESTS)
+set_tests_properties(${test_names} PROPERTIES ENVIRONMENT 
+"TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH};EXAMPLE_DIR=${PROJECT_SOURCE_DIR}/k4MarlinWrapper/examples;MARLIN_DLL=$ENV{MARLIN_DLL}:${CMAKE_CURRENT_BINARY_DIR}/libMarlinTestProcessors.so"
+)
 
-  set_tests_properties(
-    clicRec clicRec_lcio_mt clicRec_edm4hep_input
-    PROPERTIES
-    DEPENDS CLICPerformance_setup
-    )
+set_tests_properties(
+  clicRec clicRec_lcio_mt clicRec_edm4hep_input
+  PROPERTIES
+  DEPENDS CLICPerformance_setup
+)
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,7 +99,7 @@ add_test( event_header_conversion bash -c "k4run ${CMAKE_CURRENT_SOURCE_DIR}/gau
 ExternalData_Add_Target(marlinwrapper_tests)
 
 get_property(test_names DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY TESTS)
-set_tests_properties(${test_names} PROPERTIES ENVIRONMENT 
+set_tests_properties(${test_names} PROPERTIES ENVIRONMENT
 "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH};EXAMPLE_DIR=${PROJECT_SOURCE_DIR}/k4MarlinWrapper/examples;MARLIN_DLL=$ENV{MARLIN_DLL}:${CMAKE_CURRENT_BINARY_DIR}/libMarlinTestProcessors.so"
 )
 

--- a/test/src/MarlinMCRecoLinkChecker.cc
+++ b/test/src/MarlinMCRecoLinkChecker.cc
@@ -31,9 +31,9 @@ class MarlinMCRecoLinkChecker : public marlin::Processor {
 public:
   MarlinMCRecoLinkChecker();
 
-  marlin::Processor* newProcessor() override { return new MarlinMCRecoLinkChecker; }
+  marlin::Processor* newProcessor() final { return new MarlinMCRecoLinkChecker; }
 
-  void processEvent(LCEvent* evt) override;
+  void processEvent(LCEvent* evt) final;
 
 private:
   std::string m_mcCollName{};

--- a/test/src/PseudoRecoAlgorithm.cc
+++ b/test/src/PseudoRecoAlgorithm.cc
@@ -30,7 +30,7 @@ struct PseudoRecoAlgorithm final
       : Transformer(name, svcLoc, {KeyValues("InputMCs", {"MCParticles"})},
                     {KeyValues("OutputRecos", {"PseudoRecoParticles"})}) {}
 
-  edm4hep::ReconstructedParticleCollection operator()(const edm4hep::MCParticleCollection& input) const override {
+  edm4hep::ReconstructedParticleCollection operator()(const edm4hep::MCParticleCollection& input) const final {
     auto coll_out = edm4hep::ReconstructedParticleCollection();
     for (const auto& particle : input) {
       auto new_particle = coll_out.create();

--- a/test/src/TrivialMCRecoLinker.cc
+++ b/test/src/TrivialMCRecoLinker.cc
@@ -36,7 +36,7 @@ struct TrivialMCRecoLinker final
 
   edm4hep::RecoMCParticleLinkCollection operator()(
       const edm4hep::MCParticleCollection&            mcParticles,
-      const edm4hep::ReconstructedParticleCollection& recoParticles) const override {
+      const edm4hep::ReconstructedParticleCollection& recoParticles) const final {
     auto links = edm4hep::RecoMCParticleLinkCollection{};
 
     for (size_t i = 0; i < mcParticles.size(); ++i) {

--- a/test/src/TrivialMCTruthLinkerProcessor.h
+++ b/test/src/TrivialMCTruthLinkerProcessor.h
@@ -24,12 +24,12 @@ class TrivialMCTruthLinkerProcessor : public marlin::Processor {
 public:
   TrivialMCTruthLinkerProcessor();
 
-  marlin::Processor* newProcessor() override { return new TrivialMCTruthLinkerProcessor; }
+  marlin::Processor* newProcessor() final { return new TrivialMCTruthLinkerProcessor; }
 
   /** process the event - In this case simply link MCparticle[i] with
    * ReconstructedParticle[i]
    */
-  void processEvent(LCEvent* evt) override;
+  void processEvent(LCEvent* evt) final;
 
 private:
   std::string m_mcCollName{};


### PR DESCRIPTION
BEGINRELEASENOTES
- Don't use the deprecated service retrieval
- Add `final` when possible and use the default destructors instead of implementing them
- Use `!` instead of `not` in `if(...)`
- Use `!` instead of comparing to `nullptr`
- Simplify setting the environment for tests, avoiding having to duplicate the names
- Clean up some includes in header and source files

ENDRELEASENOTES