### PR TITLE
Make sure to not fail on spuriously missing collection

### DIFF
--- a/test/gaudi_opts/fccRec_e4h_input.py
+++ b/test/gaudi_opts/fccRec_e4h_input.py
@@ -1687,7 +1687,7 @@ VertexFinderUnconstrained.Parameters = {
 from Configurables import PodioOutput
 
 out = PodioOutput("PodioOutput", filename="my_output.root")
-out.outputCommands = ["keep *"]
+out.outputCommands = ["keep *", "drop RefinedVertexJets_PID_RefinedVertex"]
 
 
 algList.append(inp)


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to not fail the example in case of some spuriously missing ParticleID object that is not consistently created by LCFIPlus

ENDRELEASENOTES

In this case the culprit is https://github.com/lcfiplus/LCFIPlus/issues/69

For ILD standard reconstruction we simply patch collections on the fly: https://github.com/iLCSoft/ILDConfig/pull/149

We could also go for that here, but this is the less invasive solution.