### PR TITLE
Add support for running with IOSvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ find_package(Gaudi REQUIRED)
 find_package(LCIO REQUIRED)
 find_package(Marlin REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
-find_package(k4FWCore REQUIRED)
-find_package(k4EDM4hep2LcioConv REQUIRED)
+find_package(k4FWCore 1.2.0 REQUIRED)
+find_package(k4EDM4hep2LcioConv 0.10 REQUIRED)
 
 include(CTest)
 

--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -54,6 +54,13 @@ target_include_directories(MarlinWrapper PUBLIC
   ${LCIO_INCLUDE_DIRS}
 )
 
+# k4MarlinWrapperUtils
+gaudi_add_library(k4MarlinWrapperUtils SHARED
+  SOURCES
+    src/components/StoreUtils.cpp
+  LINK k4FWCore::k4FWCore
+)
+
 # EDM4hep2lcio
 gaudi_add_module(EDM4hep2Lcio
   SOURCES
@@ -64,6 +71,7 @@ gaudi_add_module(EDM4hep2Lcio
     ${LCIO_LIBRARIES}
     ${Marlin_LIBRARIES}
     EDM4HEP::edm4hep
+    k4MarlinWrapperUtils
 )
 
 target_include_directories(EDM4hep2Lcio PUBLIC
@@ -80,6 +88,7 @@ gaudi_add_module(Lcio2EDM4hep
     EDM4HEP::edm4hep
     k4FWCore::k4FWCore
     k4EDM4hep2LcioConv::k4EDM4hep2LcioConv
+    k4MarlinWrapperUtils
 )
 
 target_include_directories(Lcio2EDM4hep PUBLIC

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -54,7 +54,7 @@ if args.iosvc:
         "$TEST_DIR/inputFiles/", os.environ.get("INPUTFILE", "ttbar_edm4hep_frame.root")
     )
     iosvc.Output = "my_output.root"
-    iosvc.outputDstName = ["keep *, drop RefinedVertexJets_PID_RefinedVertex"]
+    iosvc.outputCommands = ["keep *, drop RefinedVertexJets_PID_RefinedVertex"]
 else:
     evtsvc = k4DataSvc("EventDataSvc")
     evtsvc.input = os.path.join(

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -2445,18 +2445,6 @@ VertexFinderUnconstrained.Parameters = {
     "UseMCP": ["0"],
 }
 
-
-<<<<<<< HEAD
-# Write output to EDM4hep
-from Configurables import PodioOutput
-
-out = PodioOutput("PodioOutput", filename="my_output.root")
-out.outputCommands = ["keep *", "drop RefinedVertexJets_PID_RefinedVertex"]
-
-
-algList.append(inp)
-=======
->>>>>>> cb3c7a3 (Add support for running with IOSvc)
 algList.append(MyAIDAProcessor)
 algList.append(EventNumber)
 algList.append(InitDD4hep)

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -54,7 +54,7 @@ if args.iosvc:
         "$TEST_DIR/inputFiles/", os.environ.get("INPUTFILE", "ttbar_edm4hep_frame.root")
     )
     iosvc.Output = "my_output.root"
-    iosvc.outputCommands = ["keep *, drop RefinedVertexJets_PID_RefinedVertex"]
+    iosvc.outputCommands = ["keep *", "drop RefinedVertexJets_PID_RefinedVertex"]
 else:
     evtsvc = k4DataSvc("EventDataSvc")
     evtsvc.input = os.path.join(
@@ -65,7 +65,7 @@ else:
     inp.OutputLevel = DEBUG
 
     out = PodioOutput("PodioOutput", filename="my_output.root")
-    out.outputCommands = ["keep *, drop RefinedVertexJets_PID_RefinedVertex"]
+    out.outputCommands = ["keep *", "drop RefinedVertexJets_PID_RefinedVertex"]
 
 MyAIDAProcessor = MarlinProcessorWrapper("MyAIDAProcessor")
 MyAIDAProcessor.OutputLevel = WARNING

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -19,10 +19,16 @@
 
 import os
 
-from Gaudi.Configuration import *
+from Gaudi.Configuration import DEBUG, WARNING
 
-from Configurables import LcioEvent, MarlinProcessorWrapper
-from k4MarlinWrapper.parseConstants import *
+from Configurables import MarlinProcessorWrapper
+from k4MarlinWrapper.parseConstants import parseConstants
+
+from Configurables import Lcio2EDM4hepTool, EDM4hep2LcioTool
+from Configurables import k4DataSvc, PodioInput, PodioOutput, EventDataSvc
+
+from k4FWCore import ApplicationMgr, IOSvc
+from k4FWCore.parseArgs import parser
 
 algList = []
 
@@ -33,22 +39,33 @@ CONSTANTS = {
 
 parseConstants(CONSTANTS)
 
-
-# For converters
-from Configurables import ToolSvc, Lcio2EDM4hepTool, EDM4hep2LcioTool
-
-
-from Configurables import k4DataSvc, PodioInput
-
-evtsvc = k4DataSvc("EventDataSvc")
-evtsvc.input = os.path.join(
-    "$TEST_DIR/inputFiles/", os.environ.get("INPUTFILE", "ttbar_edm4hep_frame.root")
+parser.add_argument(
+    "--iosvc", action="store_true", default=False, help="Use IOSvc instead of PodioDataSvc"
 )
+parser.add_argument("--rec-output", help="Output file name for the REC file")
+parser.add_argument("--dst-output", help="Output file name for the DST file")
 
+args = parser.parse_known_args()[0]
 
-inp = PodioInput("InputReader")
-inp.OutputLevel = DEBUG
+if args.iosvc:
+    evtsvc = EventDataSvc("EventDataSvc")
+    iosvc = IOSvc()
+    iosvc.Input = os.path.join(
+        "$TEST_DIR/inputFiles/", os.environ.get("INPUTFILE", "ttbar_edm4hep_frame.root")
+    )
+    iosvc.Output = "my_output.root"
+    iosvc.outputDstName = ["keep *, drop RefinedVertexJets_PID_RefinedVertex"]
+else:
+    evtsvc = k4DataSvc("EventDataSvc")
+    evtsvc.input = os.path.join(
+        "$TEST_DIR/inputFiles/", os.environ.get("INPUTFILE", "ttbar_edm4hep_frame.root")
+    )
 
+    inp = PodioInput("InputReader")
+    inp.OutputLevel = DEBUG
+
+    out = PodioOutput("PodioOutput", filename="my_output.root")
+    out.outputCommands = ["keep *, drop RefinedVertexJets_PID_RefinedVertex"]
 
 MyAIDAProcessor = MarlinProcessorWrapper("MyAIDAProcessor")
 MyAIDAProcessor.OutputLevel = WARNING
@@ -1167,7 +1184,7 @@ Output_REC.Parameters = {
     "DropCollectionTypes": [],
     "FullSubsetCollections": ["EfficientMCParticles", "InefficientMCParticles"],
     "KeepCollectionNames": [],
-    "LCIOOutputFile": ["Output_REC_e4h_input.slcio"],
+    "LCIOOutputFile": [args.rec_output],
     "LCIOWriteMode": ["WRITE_NEW"],
 }
 
@@ -1233,7 +1250,7 @@ Output_DST.Parameters = {
         "RefinedVertices",
         "RefinedVertices_RP",
     ],
-    "LCIOOutputFile": ["Output_DST_e4h_input.slcio"],
+    "LCIOOutputFile": [args.dst_output],
     "LCIOWriteMode": ["WRITE_NEW"],
 }
 
@@ -2429,6 +2446,7 @@ VertexFinderUnconstrained.Parameters = {
 }
 
 
+<<<<<<< HEAD
 # Write output to EDM4hep
 from Configurables import PodioOutput
 
@@ -2437,6 +2455,8 @@ out.outputCommands = ["keep *", "drop RefinedVertexJets_PID_RefinedVertex"]
 
 
 algList.append(inp)
+=======
+>>>>>>> cb3c7a3 (Add support for running with IOSvc)
 algList.append(MyAIDAProcessor)
 algList.append(EventNumber)
 algList.append(InitDD4hep)
@@ -2486,8 +2506,8 @@ algList.append(JetClusteringAndRefiner)
 # # algList.append(VertexFinderUnconstrained)  # Config.VertexUnconstrainedON
 algList.append(Output_REC)
 algList.append(Output_DST)
-algList.append(out)
 
-from Configurables import ApplicationMgr
+if not args.iosvc:
+    algList = [inp] + algList + [out]
 
 ApplicationMgr(TopAlg=algList, EvtSel="NONE", EvtMax=3, ExtSvc=[evtsvc], OutputLevel=WARNING)

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -42,9 +42,15 @@ parseConstants(CONSTANTS)
 parser.add_argument(
     "--iosvc", action="store_true", default=False, help="Use IOSvc instead of PodioDataSvc"
 )
-parser.add_argument("--rec-output", help="Output file name for the REC file")
-parser.add_argument("--dst-output", help="Output file name for the DST file")
-parser.add_argument("--gaudi-output", help="Output file name for the Gaudi file")
+parser.add_argument(
+    "--rec-output", default="Output_REC_e4h_input.slcio", help="Output file name for the REC file"
+)
+parser.add_argument(
+    "--dst-output", default="Output_DST_e4h_input.slcio", help="Output file name for the DST file"
+)
+parser.add_argument(
+    "--gaudi-output", default="my_output.root", help="Output file name for the Gaudi file"
+)
 
 args = parser.parse_known_args()[0]
 

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -44,6 +44,7 @@ parser.add_argument(
 )
 parser.add_argument("--rec-output", help="Output file name for the REC file")
 parser.add_argument("--dst-output", help="Output file name for the DST file")
+parser.add_argument("--gaudi-output", help="Output file name for the Gaudi file")
 
 args = parser.parse_known_args()[0]
 
@@ -53,7 +54,7 @@ if args.iosvc:
     iosvc.Input = os.path.join(
         "$TEST_DIR/inputFiles/", os.environ.get("INPUTFILE", "ttbar_edm4hep_frame.root")
     )
-    iosvc.Output = "my_output.root"
+    iosvc.Output = args.gaudi_output
     iosvc.outputCommands = ["keep *", "drop RefinedVertexJets_PID_RefinedVertex"]
 else:
     evtsvc = k4DataSvc("EventDataSvc")
@@ -64,7 +65,7 @@ else:
     inp = PodioInput("InputReader")
     inp.OutputLevel = DEBUG
 
-    out = PodioOutput("PodioOutput", filename="my_output.root")
+    out = PodioOutput("PodioOutput", filename=args.gaudi_output)
     out.outputCommands = ["keep *", "drop RefinedVertexJets_PID_RefinedVertex"]
 
 MyAIDAProcessor = MarlinProcessorWrapper("MyAIDAProcessor")

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -21,8 +21,6 @@
 
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
-#include "k4FWCore/IMetadataSvc.h"
-
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h"
 
 #include <Gaudi/Property.h>
@@ -33,7 +31,8 @@
 #include <vector>
 
 class PodioDataSvc;
-class MetadataSvc;
+class IDataProviderSvc;
+class IMetadataSvc;
 
 template <typename K, typename V> using ObjMapT = k4EDM4hep2LcioConv::VecMapT<K, V>;
 
@@ -66,7 +65,9 @@ private:
   Gaudi::Property<bool>                               m_convertAll{this, "convertAll", true};
 
   PodioDataSvc*                   m_podioDataSvc;
+  // EventDataSvc that is used together with IOSvc
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
+  // Metadata service from k4FWCore that is used together with IOSvc
   SmartIF<IMetadataSvc>           m_metadataSvc;
   std::vector<std::string>        m_collectionNames;
   std::map<uint32_t, std::string> m_idToName;

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -116,8 +116,6 @@ private:
                   std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
                   std::vector<EDM4hep2LCIOConv::TrackDqdxConvData>&  dQdxCollections);
 
-  StatusCode getAvailableCollectionsFromStore();
-
   /// Get an EDM4hep collection by name, consulting either the podio based data
   /// svc or the IOSvc
   podio::CollectionBase* getEDM4hepCollection(const std::string& name) const;

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -21,6 +21,8 @@
 
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
+#include "k4FWCore/IMetadataSvc.h"
+
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h"
 
 #include <Gaudi/Property.h>
@@ -31,6 +33,7 @@
 #include <vector>
 
 class PodioDataSvc;
+class MetadataSvc;
 
 template <typename K, typename V> using ObjMapT = k4EDM4hep2LcioConv::VecMapT<K, V>;
 
@@ -64,6 +67,7 @@ private:
 
   PodioDataSvc*                   m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
+  SmartIF<IMetadataSvc>           m_metadataSvc;
   std::vector<std::string>        m_collectionNames;
   std::map<uint32_t, std::string> m_idToName;
 

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -64,7 +64,7 @@ private:
   Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};
   Gaudi::Property<bool>                               m_convertAll{this, "convertAll", true};
 
-  PodioDataSvc*                   m_podioDataSvc;
+  PodioDataSvc* m_podioDataSvc;
   // EventDataSvc that is used together with IOSvc
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   // Metadata service from k4FWCore that is used together with IOSvc

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -64,6 +64,8 @@ private:
 
   PodioDataSvc*                   m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
+  std::vector<std::string>        m_collectionNames;
+  std::map<uint32_t, std::string> m_idToName;
 
   void convertTracks(TrackMap& tracks_vec, const std::string& e4h_coll_name, const std::string& lcio_coll_name,
                      lcio::LCEventImpl* lcio_event);
@@ -109,6 +111,8 @@ private:
                   CollectionPairMappings&                            collection_pairs,
                   std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
                   std::vector<EDM4hep2LCIOConv::TrackDqdxConvData>&  dQdxCollections);
+
+  StatusCode getAvailableCollectionsFromStore();
 
   /// Get an EDM4hep collection by name, consulting either the podio based data
   /// svc or the IOSvc

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -58,7 +58,7 @@ private:
   Gaudi::Property<std::map<std::string, std::string>> m_collNames{this, "collNameMapping", {}};
   Gaudi::Property<bool>                               m_convertAll{this, "convertAll", true};
 
-  ServiceHandle<IDataProviderSvc> m_eds;
+  ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   PodioDataSvc*                   m_podioDataSvc;
 
   // **********************************

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -22,6 +22,8 @@
 #include <Gaudi/Property.h>
 #include <GaudiKernel/AlgTool.h>
 
+#include "k4FWCore/IMetadataSvc.h"
+
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
 #include <lcio.h>
@@ -59,6 +61,7 @@ private:
   Gaudi::Property<bool>                               m_convertAll{this, "convertAll", true};
 
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
+  SmartIF<IMetadataSvc>           m_metadataSvc;
   PodioDataSvc*                   m_podioDataSvc;
 
   // **********************************

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -73,7 +73,7 @@ StatusCode EDM4hep2LcioTool::initialize() {
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
   m_metadataSvc = service("MetadataSvc", false);
-  if (!m_metadataSvc) {
+  if (!m_podioDataSvc && !m_metadataSvc) {
     error() << "Could not retrieve MetadataSvc" << endmsg;
     return StatusCode::FAILURE;
   }

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -34,7 +34,6 @@
 #include "GaudiKernel/AnyDataWrapper.h"
 #include "GaudiKernel/IDataManagerSvc.h"
 #include "GaudiKernel/IDataProviderSvc.h"
-#include "GaudiKernel/SmartDataPtr.h"
 
 #include <functional>
 #include <memory>

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -390,8 +390,8 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
     m_collectionNames = edmEvent.value().get().getAvailableCollections();
   } else if (m_collectionNames.empty()) {
     std::optional<std::map<uint32_t, std::string>> idToNameOpt(std::move(m_idToName));
-    auto collections = getAvailableCollectionsFromStore(this, idToNameOpt);
-    m_idToName = std::move(idToNameOpt.value());
+    auto                                           collections = getAvailableCollectionsFromStore(this, idToNameOpt);
+    m_idToName                                                 = std::move(idToNameOpt.value());
     m_collectionNames.insert(m_collectionNames.end(), collections.begin(), collections.end());
   }
   // Start off with the pre-defined collection name mappings

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -358,8 +358,8 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
                                   std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
                                   std::vector<EDM4hep2LCIOConv::TrackDqdxConvData>&  dQdxCollections) {
   const auto& metadata = m_podioDataSvc->getMetaDataFrame();
-  const auto collPtr  = getEDM4hepCollection(e4h_coll_name);
-  const auto fulltype = collPtr->getValueTypeName();
+  const auto  collPtr  = getEDM4hepCollection(e4h_coll_name);
+  const auto  fulltype = collPtr->getValueTypeName();
 
   debug() << "Converting type " << fulltype << " from input " << e4h_coll_name << endmsg;
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -357,10 +357,7 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
                                   lcio::LCEventImpl* lcio_event, CollectionPairMappings& collection_pairs,
                                   std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
                                   std::vector<EDM4hep2LCIOConv::TrackDqdxConvData>&  dQdxCollections) {
-  std::optional<std::reference_wrapper<podio::Frame>> metadata;
-  if (m_podioDataSvc) {
-    metadata = m_podioDataSvc->getMetaDataFrame();
-  }
+  const auto& metadata = m_podioDataSvc->getMetaDataFrame();
   const auto collPtr  = getEDM4hepCollection(e4h_coll_name);
   const auto fulltype = collPtr->getValueTypeName();
 
@@ -398,12 +395,11 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
     std::optional<std::vector<std::string>> maybeParamNames;
 
     if (m_podioDataSvc) {
-      const auto& frame = metadata.value().get();
       maybeAlgoName =
-          frame.getParameter<std::string>(podio::collMetadataParamName(e4h_coll_name, edm4hep::labels::PIDAlgoName));
+          metadata.getParameter<std::string>(podio::collMetadataParamName(e4h_coll_name, edm4hep::labels::PIDAlgoName));
       maybeAlgoType =
-          frame.getParameter<int>(podio::collMetadataParamName(e4h_coll_name, edm4hep::labels::PIDAlgoType));
-      maybeParamNames = frame.getParameter<std::vector<std::string>>(
+          metadata.getParameter<int>(podio::collMetadataParamName(e4h_coll_name, edm4hep::labels::PIDAlgoType));
+      maybeParamNames = metadata.getParameter<std::vector<std::string>>(
           podio::collMetadataParamName(e4h_coll_name, edm4hep::labels::PIDParameterNames));
 
     } else {

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -52,7 +52,7 @@ StatusCode Lcio2EDM4hepTool::initialize() {
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
   m_metadataSvc = service("MetadataSvc", false);
-  if (!m_metadataSvc) {
+  if (!m_podioDataSvc && !m_metadataSvc) {
     error() << "Could not retrieve MetadataSvc" << endmsg;
     return StatusCode::FAILURE;
   }

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -32,7 +32,6 @@
 
 #include "GaudiKernel/AnyDataWrapper.h"
 
-#include <functional>
 #include <memory>
 
 DECLARE_COMPONENT(Lcio2EDM4hepTool);

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -156,7 +156,9 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
       auto* frameWrapper = dynamic_cast<AnyDataWrapper<podio::Frame>*>(p);
       LCIO2EDM4hepConv::convertObjectParameters(the_event, frameWrapper->getData());
     } else {
-      warning() << "Could not retrieve the event frame; event parameters will not be converted. This is a known limitation when running with IOSvc without an input file." << endmsg;
+      warning() << "Could not retrieve the event frame; event parameters will not be converted. This is a known "
+                   "limitation when running with IOSvc without an input file."
+                << endmsg;
     }
   }
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -51,6 +51,12 @@ Lcio2EDM4hepTool::Lcio2EDM4hepTool(const std::string& type, const std::string& n
 StatusCode Lcio2EDM4hepTool::initialize() {
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
+  m_metadataSvc = service("MetadataSvc", false);
+  if(!m_metadataSvc) {
+    error() << "Could not retrieve MetadataSvc" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
   return AlgTool::initialize();
 }
 
@@ -227,10 +233,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
     }
   } else {
     for (const auto& [collName, pidInfo] : pidInfos) {
-      k4FWCore::putParameter(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoName), pidInfo.algoName);
-      k4FWCore::putParameter(podio::collMetadataParamName(collName, edm4hep::labels::PIDAlgoType), pidInfo.algoType());
-      k4FWCore::putParameter(podio::collMetadataParamName(collName, edm4hep::labels::PIDParameterNames),
-                             pidInfo.paramNames);
+      m_metadataSvc->put(collName, pidInfo);
     }
   }
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -147,9 +147,9 @@ namespace {
 StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   // Convert event parameters
   if (m_podioDataSvc) {
-    LCIO2EDM4hepConv::convertObjectParameters<lcio::LCEventImpl>(the_event, m_podioDataSvc->m_eventframe);
+    LCIO2EDM4hepConv::convertObjectParameters(the_event, m_podioDataSvc->m_eventframe);
   } else {
-    LCIO2EDM4hepConv::convertObjectParameters<lcio::LCEventImpl>(
+    LCIO2EDM4hepConv::convertObjectParameters(
         the_event, [](const std::string& key, const auto& value) { k4FWCore::putParameter(key, value); });
   }
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -18,6 +18,7 @@
  */
 #include "k4MarlinWrapper/converters/Lcio2EDM4hep.h"
 #include "GlobalConvertedObjectsMap.h"
+#include "StoreUtils.h"
 
 #include <EVENT/LCCollection.h>
 #include <Exceptions.h>
@@ -71,6 +72,8 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
   if (m_podioDataSvc) {
     collections = m_podioDataSvc->getEventFrame().getAvailableCollections();
   } else {
+    std::optional<std::map<uint32_t, std::string>> dummy = std::nullopt;
+    getAvailableCollectionsFromStore(this, dummy, true);
   }
   if (std::find(collections.begin(), collections.end(), collection_name) != collections.end()) {
     debug() << "Collection named " << collection_name << " already registered, skipping conversion." << endmsg;

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -71,11 +71,11 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
   if (m_podioDataSvc) {
     collections = m_podioDataSvc->getEventFrame().getAvailableCollections();
   }
-  for (const auto& name : collections) {
-    if (name == collection_name) {
-      debug() << "Collection named " << name << " already registered, skipping conversion." << endmsg;
-      return true;
-    }
+  else {
+  }
+  if (std::find(collections.begin(), collections.end(), collection_name) != collections.end()) {
+    debug() << "Collection named " << collection_name << " already registered, skipping conversion." << endmsg;
+    return true;
   }
   return false;
 }

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -73,7 +73,7 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
     collections = m_podioDataSvc->getEventFrame().getAvailableCollections();
   } else {
     std::optional<std::map<uint32_t, std::string>> dummy = std::nullopt;
-    collections = getAvailableCollectionsFromStore(this, dummy, true);
+    collections                                          = getAvailableCollectionsFromStore(this, dummy, true);
   }
   if (std::find(collections.begin(), collections.end(), collection_name) != collections.end()) {
     debug() << "Collection named " << collection_name << " already registered, skipping conversion." << endmsg;

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -156,7 +156,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
       auto* frameWrapper = dynamic_cast<AnyDataWrapper<podio::Frame>*>(p);
       LCIO2EDM4hepConv::convertObjectParameters(the_event, frameWrapper->getData());
     } else {
-      warning() << "Could not retrieve the event frame; event parameters will not be converted" << endmsg;
+      warning() << "Could not retrieve the event frame; event parameters will not be converted. This is a known limitation when running with IOSvc without an input file." << endmsg;
     }
   }
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -226,7 +226,6 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   }
 
   // Set the ParticleID meta information
-  // TODO: Clean up
   if (m_podioDataSvc) {
     auto& metadataFrame = m_podioDataSvc->getMetaDataFrame();
     for (const auto& [collName, pidInfo] : pidInfos) {

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -140,11 +140,12 @@ namespace {
 
 StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   // Convert event parameters
-  std::optional<std::reference_wrapper<podio::Frame>> frame;
   if (m_podioDataSvc) {
-    frame = m_podioDataSvc->m_eventframe;
+    LCIO2EDM4hepConv::convertObjectParameters<lcio::LCEventImpl>(the_event, m_podioDataSvc->m_eventframe);
+  } else {
+    LCIO2EDM4hepConv::convertObjectParameters<lcio::LCEventImpl>(
+        the_event, [](const std::string& key, const auto& value) { k4FWCore::putParameter(key, value); });
   }
-  LCIO2EDM4hepConv::convertObjectParameters<lcio::LCEventImpl>(the_event, frame);
 
   // Convert Event Header outside the collections loop
   if (!collectionExist(edm4hep::labels::EventHeader)) {

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -68,7 +68,6 @@ StatusCode Lcio2EDM4hepTool::finalize() { return AlgTool::finalize(); }
 // **********************************
 bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
   std::vector<std::string> collections;
-  //TODO:
   if (m_podioDataSvc) {
     collections = m_podioDataSvc->getEventFrame().getAvailableCollections();
   } else {

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -52,7 +52,7 @@ StatusCode Lcio2EDM4hepTool::initialize() {
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
   m_metadataSvc = service("MetadataSvc", false);
-  if(!m_metadataSvc) {
+  if (!m_metadataSvc) {
     error() << "Could not retrieve MetadataSvc" << endmsg;
     return StatusCode::FAILURE;
   }
@@ -70,8 +70,7 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
   //TODO:
   if (m_podioDataSvc) {
     collections = m_podioDataSvc->getEventFrame().getAvailableCollections();
-  }
-  else {
+  } else {
   }
   if (std::find(collections.begin(), collections.end(), collection_name) != collections.end()) {
     debug() << "Collection named " << collection_name << " already registered, skipping conversion." << endmsg;

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -28,9 +28,9 @@
 #include <edm4hep/utils/ParticleIDUtils.h>
 
 #include <k4FWCore/DataHandle.h>
+#include <k4FWCore/FunctionalUtils.h>
 #include <k4FWCore/MetaDataHandle.h>
 #include <k4FWCore/PodioDataSvc.h>
-#include <k4FWCore/FunctionalUtils.h>
 
 #include "GaudiKernel/AnyDataWrapper.h"
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -73,7 +73,7 @@ bool Lcio2EDM4hepTool::collectionExist(const std::string& collection_name) {
     collections = m_podioDataSvc->getEventFrame().getAvailableCollections();
   } else {
     std::optional<std::map<uint32_t, std::string>> dummy = std::nullopt;
-    getAvailableCollectionsFromStore(this, dummy, true);
+    collections = getAvailableCollectionsFromStore(this, dummy, true);
   }
   if (std::find(collections.begin(), collections.end(), collection_name) != collections.end()) {
     debug() << "Collection named " << collection_name << " already registered, skipping conversion." << endmsg;

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -16,13 +16,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "StoreUtils.h"
+
 #include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/AnyDataWrapper.h"
 #include "GaudiKernel/IDataManagerSvc.h"
 #include "GaudiKernel/IDataProviderSvc.h"
 #include "GaudiKernel/SmartDataPtr.h"
 
-#include "StoreUtils.h"
 #include "podio/Frame.h"
 
 #include "k4FWCore/FunctionalUtils.h"

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -1,0 +1,66 @@
+#include "GaudiKernel/AlgTool.h"
+#include "GaudiKernel/AnyDataWrapper.h"
+#include "GaudiKernel/IDataManagerSvc.h"
+#include "GaudiKernel/IDataProviderSvc.h"
+#include "GaudiKernel/SmartDataPtr.h"
+
+#include "StoreUtils.h"
+#include "podio/Frame.h"
+
+#include "k4FWCore/FunctionalUtils.h"
+
+#include <vector>
+#include <string>
+
+std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool*                                  thisClass,
+                                                          std::optional<std::map<uint32_t, std::string>>& idToName,
+                                                          bool returnFrameCollections
+                                                          ) {
+  std::vector<std::string> collectionNames;
+
+  SmartIF<IDataManagerSvc> mgr;
+  mgr = thisClass->evtSvc();
+
+  SmartDataPtr<DataObject> root(thisClass->evtSvc(), "/Event");
+  if (!root) {
+    thisClass->error() << "Failed to retrieve root object /Event" << endmsg;
+  }
+
+  auto pObj = root->registry();
+  if (!pObj) {
+    thisClass->error() << "Failed to retrieve the root registry object" << endmsg;
+  }
+  std::vector<IRegistry*> leaves;
+  StatusCode              sc = mgr->objectLeaves(pObj, leaves);
+  if (!sc.isSuccess()) {
+    thisClass->error() << "Failed to retrieve object leaves" << endmsg;
+  }
+  for (const auto& pReg : leaves) {
+    if (pReg->name() == k4FWCore::frameLocation) {
+      if (!returnFrameCollections)
+        continue;
+      auto wrapper = dynamic_cast<AnyDataWrapper<podio::Frame>*>(pReg->object());
+      if (!wrapper) {
+        throw std::runtime_error("Could not cast object to Frame");
+      }
+      for (const auto& name : wrapper->getData().getAvailableCollections()) {
+        collectionNames.push_back(name);
+      }
+    }
+    DataObject* p;
+    sc = thisClass->evtSvc()->retrieveObject("/Event" + pReg->name(), p);
+    if (sc.isFailure()) {
+      thisClass->error() << "Could not retrieve object " << pReg->name() << " from the EventStore" << endmsg;
+    }
+    auto wrapper = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(p);
+    if (!wrapper) {
+      continue;
+    }
+    // Remove the leading /
+    collectionNames.push_back(pReg->name().substr(1, pReg->name().size() - 1));
+    if (idToName) {
+      idToName->emplace(wrapper->getData()->getID(), pReg->name());
+    }
+  }
+  return collectionNames;
+}

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -28,9 +28,14 @@
 
 #include "k4FWCore/FunctionalUtils.h"
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+// This is a reimplementation of functionality to retrieve collections from the
+// store that can be found in Writer.cpp in k4FWCore with some modifications
+// that are specific to the usage of this function in the converters, like
+// returning also a map from collection ID to collection name
 std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool*                                  thisClass,
                                                           std::optional<std::map<uint32_t, std::string>>& idToName,
                                                           bool returnFrameCollections) {
@@ -46,12 +51,12 @@ std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool*        
 
   auto pObj = root->registry();
   if (!pObj) {
-    thisClass->error() << "Failed to retrieve the root registry object" << endmsg;
+    throw std::runtime_error("Failed to retrieve the root registry object");
   }
   std::vector<IRegistry*> leaves;
   StatusCode              sc = mgr->objectLeaves(pObj, leaves);
   if (!sc.isSuccess()) {
-    thisClass->error() << "Failed to retrieve object leaves" << endmsg;
+    throw std::runtime_error("Failed to retrieve object leaves");
   }
   for (const auto& pReg : leaves) {
     if (pReg->name() == k4FWCore::frameLocation) {

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/AnyDataWrapper.h"
 #include "GaudiKernel/IDataManagerSvc.h"
@@ -9,13 +27,12 @@
 
 #include "k4FWCore/FunctionalUtils.h"
 
-#include <vector>
 #include <string>
+#include <vector>
 
 std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool*                                  thisClass,
                                                           std::optional<std::map<uint32_t, std::string>>& idToName,
-                                                          bool returnFrameCollections
-                                                          ) {
+                                                          bool returnFrameCollections) {
   std::vector<std::string> collectionNames;
 
   SmartIF<IDataManagerSvc> mgr;

--- a/k4MarlinWrapper/src/components/StoreUtils.h
+++ b/k4MarlinWrapper/src/components/StoreUtils.h
@@ -21,6 +21,9 @@
 #include <string>
 #include <vector>
 
+// This functionality is used in the Writer from k4FWCore and is reimplemented
+// here with some additions to make it useful for converting both from EDM4hep
+// to LCIO and vice versa
 std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool*                                  thisClass,
                                                           std::optional<std::map<uint32_t, std::string>>& idToName,
                                                           bool returnFrameCollections = false);

--- a/k4MarlinWrapper/src/components/StoreUtils.h
+++ b/k4MarlinWrapper/src/components/StoreUtils.h
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "GaudiKernel/AlgTool.h"
 
 #include <string>

--- a/k4MarlinWrapper/src/components/StoreUtils.h
+++ b/k4MarlinWrapper/src/components/StoreUtils.h
@@ -1,0 +1,8 @@
+#include "GaudiKernel/AlgTool.h"
+
+#include <string>
+#include <vector>
+
+std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool*                                  thisClass,
+                                                          std::optional<std::map<uint32_t, std::string>>& idToName,
+                                                          bool returnFrameCollections = false);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,7 @@ set_tests_properties ( same_num_io
 # Test clicReconstruction with EDM4hep input and output
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --no-iosvc")
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input_iosvc COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --iosvc")
+add_test( clicRec_edm4hep_input_compare_output bash -c "diff <(podio-dump CLICPerformance/clicConfig/my_output.root | grep -v "input file:") <(podio-dump CLICPerformance/clicConfig/my_output_iosvc.root | grep -v "input file:")")
 
 # Run clicReconstruction sequence with LCIO input and output, no converters, with inter-event parallelism
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_lcio_mt COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_lcio_mt.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/testSimulation.slcio}")
@@ -115,4 +116,9 @@ set_tests_properties(
   DEPENDS CLICPerformance_setup
 )
 
+set_tests_properties(
+  clicRec_edm4hep_input_compare_output
+  PROPERTIES
+  DEPENDS clicRec_edm4hep_input clicRec_edm4hep_input_iosvc
+)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,7 +77,8 @@ set_tests_properties ( same_num_io
     PASS_REGULAR_EXPRESSION "Input and output have same number of events")
 
 # Test clicReconstruction with EDM4hep input and output
-ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}")
+ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --no-iosvc")
+ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input_iosvc COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --iosvc")
 
 # Run clicReconstruction sequence with LCIO input and output, no converters, with inter-event parallelism
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_lcio_mt COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_lcio_mt.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/testSimulation.slcio}")
@@ -88,10 +89,15 @@ add_test( clic_geo_test ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/geoTest_
 # Test for checking whether the converters can resolve relations across
 # multiple processors
 ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --EventDataSvc.input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
+ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
 
 ExternalData_Add_Test( marlinwrapper_tests
   NAME link_conversion_edm4hep_to_lcio
   COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+)
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME link_conversion_edm4hep_to_lcio_iosvc
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --iosvc --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )
 
 add_test( event_header_conversion bash -c "k4run ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/createEventHeader.py && anajob test.slcio | grep 'EVENT: 42'" )
@@ -104,7 +110,7 @@ set_tests_properties(${test_names} PROPERTIES ENVIRONMENT
 )
 
 set_tests_properties(
-  clicRec clicRec_lcio_mt clicRec_edm4hep_input
+  clicRec clicRec_lcio_mt clicRec_edm4hep_input clicRec_edm4hep_input_iosvc
   PROPERTIES
   DEPENDS CLICPerformance_setup
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,7 +79,7 @@ set_tests_properties ( same_num_io
 # Test clicReconstruction with EDM4hep input and output
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --no-iosvc")
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input_iosvc COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --iosvc")
-add_test( clicRec_edm4hep_input_compare_output bash -c "diff <(podio-dump CLICPerformance/clicConfig/my_output.root | grep -v "input file:") <(podio-dump CLICPerformance/clicConfig/my_output_iosvc.root | grep -v "input file:")")
+add_test( clicRec_edm4hep_input_compare_output bash -c "diff <(podio-dump CLICPerformance/clicConfig/my_output.root | grep -v 'input file:') <(podio-dump CLICPerformance/clicConfig/my_output_iosvc.root | grep -v 'input file:')")
 
 # Run clicReconstruction sequence with LCIO input and output, no converters, with inter-event parallelism
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_lcio_mt COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_lcio_mt.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/testSimulation.slcio}")
@@ -119,6 +119,6 @@ set_tests_properties(
 set_tests_properties(
   clicRec_edm4hep_input_compare_output
   PROPERTIES
-  DEPENDS clicRec_edm4hep_input clicRec_edm4hep_input_iosvc
+  DEPENDS "clicRec_edm4hep_input;clicRec_edm4hep_input_iosvc"
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ limitations under the License.
 gaudi_add_module(GaudiTestAlgorithms
   SOURCES
     src/MCRecoLinkChecker.cc
+    src/MCRecoLinkCheckerFunctional.cc
     src/PseudoRecoAlgorithm.cc
     src/TrivialMCRecoLinker.cc
   LINK
@@ -91,6 +92,7 @@ add_test( clic_geo_test ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/geoTest_
 # multiple processors
 ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --EventDataSvc.input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
 ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
+ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc_functional COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --use-functional-checker --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
 
 ExternalData_Add_Test( marlinwrapper_tests
   NAME link_conversion_edm4hep_to_lcio

--- a/test/scripts/clicRec_e4h_input.sh
+++ b/test/scripts/clicRec_e4h_input.sh
@@ -35,10 +35,10 @@ else
   echo "Wrong argument $2"
   return 1
 fi
-k4run $EXAMPLE_DIR/clicRec_e4h_input.py ${file_arg} --rec-output Output_REC_e4h_input$iosvc.slcio --dst-output Output_DST_e4h_input$iosvc.slcio
+k4run $EXAMPLE_DIR/clicRec_e4h_input.py ${file_arg} --rec-output Output_REC_e4h_input$iosvc.slcio --dst-output Output_DST_e4h_input$iosvc.slcio --gaudi-output my_output$iosvc.root
 
 input_num_events=$(python $TEST_DIR/python/root_num_events.py $1)
-output_num_events=$(python $TEST_DIR/python/root_num_events.py my_output.root)
+output_num_events=$(python $TEST_DIR/python/root_num_events.py my_output$iosvc.root)
 
 # First check do we have the same number of events in input and output
 if [ "$input_num_events" != "$output_num_events" ]; then

--- a/test/src/MCRecoLinkCheckerFunctional.cc
+++ b/test/src/MCRecoLinkCheckerFunctional.cc
@@ -20,8 +20,7 @@
 
 MCRecoLinkCheckerFunctional::MCRecoLinkCheckerFunctional(const std::string& name, ISvcLocator* svcLoc)
     : Consumer(name, svcLoc,
-               {KeyValues("InputMCRecoLinks", {"InputMCRecoLinks"}),
-                KeyValues("InputMCs", {"InputMCs"}),
+               {KeyValues("InputMCRecoLinks", {"InputMCRecoLinks"}), KeyValues("InputMCs", {"InputMCs"}),
                 KeyValues("InputRecos", {"InputRecos"})}) {}
 
 void MCRecoLinkCheckerFunctional::operator()(const edm4hep::RecoMCParticleLinkCollection&    relationColl,

--- a/test/src/MCRecoLinkCheckerFunctional.cc
+++ b/test/src/MCRecoLinkCheckerFunctional.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "MCRecoLinkCheckerFunctional.h"
+
+MCRecoLinkCheckerFunctional::MCRecoLinkCheckerFunctional(const std::string& name, ISvcLocator* svcLoc)
+    : Consumer(name, svcLoc,
+               {KeyValues("InputMCRecoLinks", {"InputMCRecoLinks"}),
+                KeyValues("InputMCs", {"InputMCs"}),
+                KeyValues("InputRecos", {"InputRecos"})}) {}
+
+void MCRecoLinkCheckerFunctional::operator()(const edm4hep::RecoMCParticleLinkCollection&    relationColl,
+                                             const edm4hep::MCParticleCollection&            mcColl,
+                                             const edm4hep::ReconstructedParticleCollection& recoColl) const {
+  if (relationColl.size() != mcColl.size()) {
+    error() << "The MCReco relation collection does not have the expected size (expected: " << relationColl.size()
+            << ", actual: " << mcColl.size() << ")" << endmsg;
+    throw std::runtime_error(
+        "MCRecoLinkCheckerFunctional: The MCReco relation collection does not have the expected size");
+  }
+
+  for (size_t i = 0; i < mcColl.size(); ++i) {
+    const auto mc       = mcColl[i];
+    const auto reco     = recoColl[i];
+    const auto relation = relationColl[i];
+
+    if (relation.getWeight() != i) {
+      error() << "Relation " << i << " does not not have the correct weight (expected: " << i
+              << ", actual: " << relation.getWeight() << ")" << endmsg;
+      throw std::runtime_error("The MCReco relation collection does not have the expected weight");
+    }
+
+    if (!(relation.getTo() == mc)) {
+      auto relMC = relation.getTo();
+      error() << "Relation " << i
+              << " does not point to the correct MCParticle (expected: " << mc.getObjectID().collectionID << "|"
+              << mc.getObjectID().index << ", actual: " << relMC.getObjectID().collectionID << "|"
+              << relMC.getObjectID().index << ")" << endmsg;
+      throw std::runtime_error("The MCReco relation collection does not point to the correct MCParticle");
+    }
+
+    if (!(relation.getFrom() == reco)) {
+      auto relRec = relation.getFrom();
+      error() << "Relation " << i
+              << " does not point to the correct RecoParticle (expected: " << reco.getObjectID().collectionID << "|"
+              << reco.getObjectID().index << ", actual: " << relRec.getObjectID().collectionID << "|"
+              << relRec.getObjectID().index << ")" << endmsg;
+      throw std::runtime_error("The MCReco relation collection does not point to the correct RecoParticle");
+    }
+  }
+}
+
+DECLARE_COMPONENT(MCRecoLinkCheckerFunctional)

--- a/test/src/MCRecoLinkCheckerFunctional.h
+++ b/test/src/MCRecoLinkCheckerFunctional.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef K4MARLINWRAPPER_TEST_MCRECOLINKCHECKERFUNCTIONAL_H
+#define K4MARLINWRAPPER_TEST_MCRECOLINKCHECKERFUNCTIONAL_H
+
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/RecoMCParticleLinkCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
+
+#include "k4FWCore/Consumer.h"
+
+struct MCRecoLinkCheckerFunctional final
+    : k4FWCore::Consumer<void(const edm4hep::RecoMCParticleLinkCollection&, const edm4hep::MCParticleCollection&,
+                              const edm4hep::ReconstructedParticleCollection&)> {
+  MCRecoLinkCheckerFunctional(const std::string& name, ISvcLocator* svcLoc);
+
+  void operator()(const edm4hep::RecoMCParticleLinkCollection&    relationColl,
+                  const edm4hep::MCParticleCollection&            mcColl,
+                  const edm4hep::ReconstructedParticleCollection& recoColl) const override;
+};
+
+#endif  // K4MARLINWRAPPER_TEST_MCRECOLINKCHECKERFUNCTIONAL_H


### PR DESCRIPTION
BEGINRELEASENOTES
- Add support for running the wrapper with `IOSvc` with a few tests:
  - Run the CLIC reconstruction with `IOSvc` (proves processors run under IOSvc, producing the same output).
  - Run `global_converter_maps` with `IOSvc`, where a functional algorithm produces output that is used by a Marlin processor and the output of the two is used either by a `Gaudi::Algorithm` or a functional algorithm (proves processors can take input from functional algorithms and functional algorithms can take input from processors).
  - Run `test_link_conversion_edm4hep` with `IOSvc`, where links produced by functional algorithms are checked by Marlin processors.

ENDRELEASENOTES

- [x] Needs https://github.com/key4hep/k4FWCore/pull/273
- [x] Needs https://github.com/key4hep/k4FWCore/pull/280

Fix #202 