### PR TITLE
Use the available tag from k4EDM4hep2LcioConv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ find_package(LCIO REQUIRED)
 find_package(Marlin REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
 find_package(k4FWCore 1.2.0 REQUIRED)
-find_package(k4EDM4hep2LcioConv 0.10 REQUIRED)
+find_package(k4EDM4hep2LcioConv 0.11 REQUIRED)
 
 include(CTest)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Require the minimal version of k4EDM4hep2LcioConv to be 0.11 as that is a working tag

ENDRELEASENOTES

See: https://github.com/key4hep/k4EDM4hep2LcioConv/pull/110
