### PR TITLE
Retrieve the MetadataSvc only when not using PodioDataSvc

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -72,10 +72,12 @@ StatusCode EDM4hep2LcioTool::initialize() {
 
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
-  m_metadataSvc = service("MetadataSvc", false);
-  if (!m_podioDataSvc && !m_metadataSvc) {
-    error() << "Could not retrieve MetadataSvc" << endmsg;
-    return StatusCode::FAILURE;
+  if (!m_podioDataSvc) {
+    m_metadataSvc = service("MetadataSvc", false);
+    if (!m_metadataSvc) {
+      error() << "Could not retrieve MetadataSvc" << endmsg;
+      return StatusCode::FAILURE;
+    }
   }
 
   return AlgTool::initialize();

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -53,10 +53,12 @@ Lcio2EDM4hepTool::Lcio2EDM4hepTool(const std::string& type, const std::string& n
 StatusCode Lcio2EDM4hepTool::initialize() {
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
-  m_metadataSvc = service("MetadataSvc", false);
-  if (!m_podioDataSvc && !m_metadataSvc) {
-    error() << "Could not retrieve MetadataSvc" << endmsg;
-    return StatusCode::FAILURE;
+  if (!m_podioDataSvc) {
+    m_metadataSvc = service("MetadataSvc", false);
+    if (!m_metadataSvc) {
+      error() << "Could not retrieve MetadataSvc" << endmsg;
+      return StatusCode::FAILURE;
+    }
   }
 
   return AlgTool::initialize();


### PR DESCRIPTION
Avoid errors like:
```
ToolSvc.lcio2ED...  ERROR ServiceLocatorHelper::service: can not locate service MetadataSvc
```
when running the Marlin wrapper. I think it is only a harmless error message.

BEGINRELEASENOTES
- Try to retrieve the MetadataSvc only when not using PodioDataSvc to avoid a lookup error when using the Marlin wrapper.

ENDRELEASENOTES