### PR TITLE
Make it possible to skip n events when reading LCIO files

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/LcioEventAlgo.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/LcioEventAlgo.h
@@ -40,6 +40,7 @@ public:
 
 private:
   Gaudi::Property<std::vector<std::string>> m_fileNames{this, "Files", {}};
+  Gaudi::Property<int>                      m_skipNEvents{this, "skipNEvents", 0};
   MT::LCReader*                             m_reader = nullptr;
   int                                       m_numberOfEvents{};
   mutable int                               m_currentEvent{};  // No atomicity necessary since not re-entrant

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -44,8 +44,9 @@ StatusCode LcioEvent::initialize() {
   m_reader = new MT::LCReader(0);
   m_reader->open(m_fileNames);
   m_numberOfEvents = m_reader->getNumberOfEvents();
+  m_reader->skipNEvents(m_skipNEvents.value());
   info() << "Initialized the LcioEvent Algo. Reading from " << m_fileNames.size() << " with " << m_numberOfEvents
-         << " events in total." << endmsg;
+         << " events in total. Skipping the first " << m_skipNEvents << " events." << endmsg;
   return StatusCode::SUCCESS;
 }
 

--- a/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
+++ b/k4MarlinWrapper/src/components/LcioEventAlgo.cpp
@@ -45,6 +45,8 @@ StatusCode LcioEvent::initialize() {
   m_reader->open(m_fileNames);
   m_numberOfEvents = m_reader->getNumberOfEvents();
   m_reader->skipNEvents(m_skipNEvents.value());
+  // Make sure that we still stop at the right time even if we skip events
+  m_currentEvent = m_skipNEvents;
   info() << "Initialized the LcioEvent Algo. Reading from " << m_fileNames.size() << " with " << m_numberOfEvents
          << " events in total. Skipping the first " << m_skipNEvents << " events." << endmsg;
   return StatusCode::SUCCESS;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,11 @@ set_tests_properties ( same_num_io
   PROPERTIES
     PASS_REGULAR_EXPRESSION "Input and output have same number of events")
 
+add_test( skip_events bash -c ${CMAKE_CURRENT_SOURCE_DIR}/scripts/skip_events.sh )
+set_tests_properties( skip_events
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "Output has expected number of events")
+
 # Test clicReconstruction with EDM4hep input and output
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --no-iosvc")
 ExternalData_Add_Test( marlinwrapper_tests NAME clicRec_edm4hep_input_iosvc COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/clicRec_e4h_input.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --iosvc")

--- a/test/gaudi_opts/same_num_io.py
+++ b/test/gaudi_opts/same_num_io.py
@@ -21,6 +21,11 @@ import os
 from Gaudi.Configuration import *
 
 from Configurables import LcioEvent, EventDataSvc, MarlinProcessorWrapper
+from k4FWCore.parseArgs import parser
+
+parser.add_argument("--outputFile", help="The name of the output file", default="Output_DST.slcio")
+
+my_args = parser.parse_known_args()[0]
 
 algList = []
 evtsvc = EventDataSvc()
@@ -92,7 +97,7 @@ Output_DST.Parameters = {
         "RefinedVertices",
         "RefinedVertices_RP",
     ],
-    "LCIOOutputFile": ["Output_DST.slcio"],
+    "LCIOOutputFile": [my_args.outputFile],
     "LCIOWriteMode": ["WRITE_NEW"],
 }
 

--- a/test/scripts/skip_events.sh
+++ b/test/scripts/skip_events.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+##
+## Copyright (c) 2019-2024 Key4hep-Project.
+##
+## This file is part of Key4hep.
+## See https://key4hep.github.io/key4hep-doc/ for further info.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+# set -eu
+
+if [ ! -d $TEST_DIR/inputFiles/ ]; then
+  mkdir $TEST_DIR/inputFiles
+fi
+
+if [ ! -f $TEST_DIR/inputFiles/muons.slcio ]; then
+  wget https://github.com/AIDASoft/DD4hep/raw/master/DDTest/inputFiles/muons.slcio -P $TEST_DIR/inputFiles/
+fi
+
+k4run $TEST_DIR/gaudi_opts/same_num_io.py --num-events=-1 --LcioEvent.skipNEvents=5 --outputFile=Output_DST_skipEvents.slcio
+
+input_num_events=$(lcio_event_counter $TEST_DIR/inputFiles/muons.slcio)
+output_num_events=$(lcio_event_counter Output_DST_skipEvents.slcio)
+expected_events=$(($input_num_events - 5))
+
+if [ "$output_num_events" = "$expected_events" ]; then
+  echo "Output has expected number of events"
+else
+  echo "ERROR: Output does not have the expected number of events: " ${expected_events} " vs " ${output_num_events}
+fi


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `skipNEvents` property to the `LcioEvent` algorithm to make it possible to skip the first N input LCIO events.
  - Assuming default algorithm name, `--LcioEvent.skipNEvents=<N>` can be used to change this parameter from the command line.

ENDRELEASENOTES

- [x] tests
