### PR TITLE
Fix the name of the TrackerHitPlane map to consider them in relations properly

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -486,12 +486,16 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   auto  globalObjMapWrapper = static_cast<AnyDataWrapper<GlobalConvertedObjectsMap>*>(obj);
   auto& globalObjMap        = globalObjMapWrapper->getData();
 
+  debug() << "Updating global object map" << endmsg;
   globalObjMap.update(collection_pairs);
 
+  debug() << "Resolving relations between objects" << endmsg;
   EDM4hep2LCIOConv::resolveRelations(collection_pairs, globalObjMap);
 
   // Now we can convert the links and add them to the event
+  debug() << "Converting " << linkCollections.size() << " link collections to LCRelation collections" << endmsg;
   for (auto& [name, coll] : EDM4hep2LCIOConv::createLCRelationCollections(linkCollections, globalObjMap)) {
+    debug() << "Adding LCRelation collection " << name << " of type " << coll->getTypeName() << endmsg;
     lcio_event->addCollection(coll.release(), name);
   }
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -45,7 +45,7 @@ using namespace k4MarlinWrapper;
 struct CollectionPairMappings {
   TrackMap           tracks{};
   TrackerHitMap      trackerHits{};
-  TrackerHitPlaneMap trackerHitsPlane{};
+  TrackerHitPlaneMap trackerHitPlanes{};
   SimTrackerHitMap   simTrackerHits{};
   CaloHitMap         caloHits{};
   RawCaloHitMap      rawCaloHits{};
@@ -335,7 +335,7 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
   } else if (fulltype == "edm4hep::TrackerHit" || fulltype == "edm4hep::TrackerHit3D") {
     convertTrackerHits(collection_pairs.trackerHits, e4h_coll_name, lcio_coll_name, lcio_event);
   } else if (fulltype == "edm4hep::TrackerHitPlane") {
-    convertTrackerHitPlanes(collection_pairs.trackerHitsPlane, e4h_coll_name, lcio_coll_name, lcio_event);
+    convertTrackerHitPlanes(collection_pairs.trackerHitPlanes, e4h_coll_name, lcio_coll_name, lcio_event);
   } else if (fulltype == "edm4hep::SimTrackerHit") {
     convertSimTrackerHits(collection_pairs.simTrackerHits, e4h_coll_name, lcio_coll_name, lcio_event);
   } else if (fulltype == "edm4hep::CalorimeterHit") {

--- a/k4MarlinWrapper/src/components/GlobalConvertedObjectsMap.h
+++ b/k4MarlinWrapper/src/components/GlobalConvertedObjectsMap.h
@@ -64,12 +64,6 @@ namespace k4MarlinWrapper {
     }
   }
 
-  namespace detail {
-    /// Detectors for checking whether T has a trackerHitPlanes and a particleIDs map
-    template <typename T> using has_trkhit_plane = decltype(std::declval<T>().trackerHitPlanes);
-    template <typename T> using has_particle_id  = decltype(std::declval<T>().particleIDs);
-  }  // namespace detail
-
   /**
    * The LCIO <-> EDM4hep object mapping that holds the relations between all
    * converted objects from all converters that are running.
@@ -108,13 +102,8 @@ namespace k4MarlinWrapper {
       updateMap(vertices, localMap.vertices);
       updateMap(recoParticles, localMap.recoParticles);
       updateMap(mcParticles, localMap.mcParticles);
-
-      if constexpr (det::is_detected_v<detail::has_trkhit_plane, ObjectMap>) {
-        updateMap(trackerHitPlanes, localMap.trackerHitPlanes);
-      }
-      if constexpr (det::is_detected_v<detail::has_particle_id, ObjectMap>) {
-        updateMap(particleIDs, localMap.particleIDs);
-      }
+      updateMap(trackerHitPlanes, localMap.trackerHitPlanes);
+      updateMap(particleIDs, localMap.particleIDs);
     }
   };
 }  // namespace k4MarlinWrapper


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the `trackerHitPlanes` name of the map going from EDM4hep to LCIO to make it work properly.
- Remove some no longer necessary special handling of ParticleID and TrackerHitPlane maps.

ENDRELEASENOTES

See https://github.com/key4hep/CLDConfig/issues/64 and https://github.com/key4hep/k4EDM4hep2LcioConv/pull/112 for more details