### PR TITLE
Fix missing collections with IOSvc when using convertAll=True

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,6 +99,8 @@ add_test( clic_geo_test ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/geoTest_
 ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --EventDataSvc.input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
 ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
 ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc_functional COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --use-functional-checker --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
+ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc_algorithm COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --use-gaudi-algorithm --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --IOSvc.Output=global_converter_maps_iosvc_algorithm.root)
+ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc_algorithm_functional COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --use-gaudi-algorithm --use-functional-checker --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --IOSvc.Output=global_converter_maps_iosvc_algorithm_functional.root)
 
 ExternalData_Add_Test( marlinwrapper_tests
   NAME link_conversion_edm4hep_to_lcio

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ gaudi_add_module(GaudiTestAlgorithms
     src/MCRecoLinkChecker.cc
     src/MCRecoLinkCheckerFunctional.cc
     src/PseudoRecoAlgorithm.cc
+    src/PseudoRecoFunctional.cc
     src/TrivialMCRecoLinker.cc
   LINK
     Gaudi::GaudiKernel
@@ -106,6 +107,10 @@ ExternalData_Add_Test( marlinwrapper_tests
 ExternalData_Add_Test( marlinwrapper_tests
   NAME link_conversion_edm4hep_to_lcio_iosvc
   COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --iosvc --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+)
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME link_conversion_edm4hep_to_lcio_iosvc_gaudi_algorithm
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --iosvc --use-gaudi-algorithm --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )
 
 add_test( event_header_conversion bash -c "k4run ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/createEventHeader.py && anajob test.slcio | grep 'EVENT: 42'" )

--- a/test/README.md
+++ b/test/README.md
@@ -42,8 +42,10 @@ wrapped MarlinProcessor, one GaudiAlgorithm and one Gaudi Functional algorithm
 plus some converters in-between them:
 - `PodioInput` to read the *MCParticles* collection from the input file (in
   EDM4hep format)
-- [`PseudoRecoAlgorithm`](./src/PseudoRecoAlgorithm.cc) creates a reco particle
-  for every MC particle in the input collection
+- [`PseudoRecoFunctional`](./src/PseudoRecoFunctional.cc) creates a reco
+  particle for every MC particle in the input collection (`PseudoRecoAlgorithm`
+  does the same but implementing a `Gaudi::Algorithm` instead of a functional
+  algorithm
   - An EDM4hep to LCIO converter converts the input MC particles and the
     reconstructed particles that are created by the algorithm
 - [`TrivalMCTruthLinkerProcessor`](./src/TrivialMCTruthLinkerProcessor.cc)

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -29,7 +29,7 @@ from Configurables import (
     Lcio2EDM4hepTool,
     EDM4hep2LcioTool,
     MCRecoLinkChecker,
-    PseudoRecoAlgorithm,
+    PseudoRecoFunctional,
     EventDataSvc,
 )
 
@@ -68,8 +68,8 @@ else:
     podioOutput = PodioOutput("OutputWriter")
     podioOutput.filename = "global_converter_maps.root"
 
-PseudoRecoAlg = PseudoRecoAlgorithm(
-    "PseudoRecoAlgorithm", InputMCs=["MCParticles"], OutputRecos=["PseudoRecoParticles"]
+PseudoRecoAlg = PseudoRecoFunctional(
+    "PseudoRecoFunctional", InputMCs=["MCParticles"], OutputRecos=["PseudoRecoParticles"]
 )
 
 inputConverter = EDM4hep2LcioTool("InputConverter")

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -30,6 +30,7 @@ from Configurables import (
     EDM4hep2LcioTool,
     MCRecoLinkChecker,
     PseudoRecoFunctional,
+    PseudoRecoAlgorithm,
     EventDataSvc,
 )
 
@@ -42,6 +43,12 @@ parser.add_argument(
 )
 parser.add_argument(
     "--use-functional-checker", action="store_true", default=False, help="Use functional checker"
+)
+parser.add_argument(
+    "--use-gaudi-algorithm",
+    action="store_true",
+    default=False,
+    help="Use an algorithm based on Gaudi::Algorithm to populate the TES",
 )
 
 args = parser.parse_known_args()[0]
@@ -68,9 +75,16 @@ else:
     podioOutput = PodioOutput("OutputWriter")
     podioOutput.filename = "global_converter_maps.root"
 
-PseudoRecoAlg = PseudoRecoFunctional(
-    "PseudoRecoFunctional", InputMCs=["MCParticles"], OutputRecos=["PseudoRecoParticles"]
-)
+if args.use_gaudi_algorithm:
+    PseudoRecoAlg = PseudoRecoAlgorithm(
+        "PseudoRecoAlgorithm", InputMCs="MCParticles", OutputRecos="PseudoRecoParticles"
+    )
+else:
+    PseudoRecoAlg = PseudoRecoFunctional(
+        "PseudoRecoFunctional",
+        InputMCs=["MCParticles"],
+        OutputRecos=["PseudoRecoParticles"],
+    )
 
 inputConverter = EDM4hep2LcioTool("InputConverter")
 inputConverter.convertAll = False

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -87,7 +87,15 @@ MarlinMCLinkChecker = MarlinProcessorWrapper(
 )
 
 mcLinkConverter = EDM4hep2LcioTool("MCLinkConverterToEDM4hep")
-mcLinkConverter.convertAll = True
+if args.use_gaudi_algorithm:
+    mcLinkConverter.convertAll = True
+else:
+    mcLinkConverter.convertAll = False
+    mcLinkConverter.collNameMapping = {
+        "TrivialMCRecoLinks": "TrivialMCRecoLinks",
+        "MCParticles": "MCParticles",
+        "PseudoRecoParticles": "PseudoRecoParticles",
+    }
 mcLinkConverter.OutputLevel = DEBUG
 MarlinMCLinkChecker.EDM4hep2LcioTool = mcLinkConverter
 

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -87,15 +87,7 @@ MarlinMCLinkChecker = MarlinProcessorWrapper(
 )
 
 mcLinkConverter = EDM4hep2LcioTool("MCLinkConverterToEDM4hep")
-if args.use_gaudi_algorithm:
-    mcLinkConverter.convertAll = True
-else:
-    mcLinkConverter.convertAll = False
-    mcLinkConverter.collNameMapping = {
-        "TrivialMCRecoLinks": "TrivialMCRecoLinks",
-        "MCParticles": "MCParticles",
-        "PseudoRecoParticles": "PseudoRecoParticles",
-    }
+mcLinkConverter.convertAll = True
 mcLinkConverter.OutputLevel = DEBUG
 MarlinMCLinkChecker.EDM4hep2LcioTool = mcLinkConverter
 

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -87,15 +87,12 @@ MarlinMCLinkChecker = MarlinProcessorWrapper(
 )
 
 mcLinkConverter = EDM4hep2LcioTool("MCLinkConverterToEDM4hep")
-if args.use_gaudi_algorithm:
-    mcLinkConverter.convertAll = True
-else:
-    mcLinkConverter.convertAll = False
-    mcLinkConverter.collNameMapping = {
-        "TrivialMCRecoLinks": "TrivialMCRecoLinks",
-        "MCParticles": "MCParticles",
-        "PseudoRecoParticles": "PseudoRecoParticles",
-    }
+mcLinkConverter.convertAll = True
+mcLinkConverter.collNameMapping = {
+    "TrivialMCRecoLinks": "TrivialMCRecoLinks",
+    "MCParticles": "MCParticles",
+    "PseudoRecoParticles": "PseudoRecoParticles",
+}
 mcLinkConverter.OutputLevel = DEBUG
 MarlinMCLinkChecker.EDM4hep2LcioTool = mcLinkConverter
 

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -43,7 +43,7 @@ parser.add_argument(
     "--use-gaudi-algorithm",
     action="store_true",
     default=False,
-    help="Use IOSvc instead of PodioDataSvc",
+    help="Use an algorithm based on Gaudi::Algorithm instead of a functional algorithm",
 )
 args = parser.parse_known_args()[0]
 

--- a/test/src/PseudoRecoAlgorithm.h
+++ b/test/src/PseudoRecoAlgorithm.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
+
+#include "k4FWCore/DataHandle.h"
+
+#include "Gaudi/Algorithm.h"
+
+#include <string>
+
+class PseudoRecoAlgorithm : public Gaudi::Algorithm {
+public:
+  explicit PseudoRecoAlgorithm(const std::string& name, ISvcLocator* pSL);
+  StatusCode execute(const EventContext&) const override;
+
+private:
+  mutable DataHandle<edm4hep::MCParticleCollection> m_mcCollHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_recoCollHandle{"RecoParticles",
+                                                                                Gaudi::DataHandle::Writer, this};
+};

--- a/test/src/PseudoRecoFunctional.cc
+++ b/test/src/PseudoRecoFunctional.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
+
+#include "k4FWCore/Transformer.h"
+
+#include <string>
+
+struct PseudoRecoFunctional final
+    : k4FWCore::Transformer<edm4hep::ReconstructedParticleCollection(const edm4hep::MCParticleCollection&)> {
+  PseudoRecoFunctional(const std::string& name, ISvcLocator* svcLoc)
+      : Transformer(name, svcLoc, {KeyValues("InputMCs", {"MCParticles"})},
+                    {KeyValues("OutputRecos", {"PseudoRecoParticles"})}) {}
+
+  edm4hep::ReconstructedParticleCollection operator()(const edm4hep::MCParticleCollection& input) const final {
+    auto coll_out = edm4hep::ReconstructedParticleCollection();
+    for (const auto& particle : input) {
+      auto new_particle = coll_out.create();
+      new_particle.setCharge(particle.getCharge());
+      new_particle.setMomentum({static_cast<float>(particle.getMomentum()[0]),
+                                static_cast<float>(particle.getMomentum()[1]),
+                                static_cast<float>(particle.getMomentum()[2])});
+      new_particle.setEnergy(particle.getEnergy());
+    }
+    return coll_out;
+  }
+};
+
+DECLARE_COMPONENT(PseudoRecoFunctional)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix missing collections with IOSvc when using `convertAll=True`
- Add a test that would fail without this fix
- Rename `PseudoRecoAlgorithm` to `PseudoRecoFunctional` and create a new  `PseudoRecoAlgorithm` that implements a `Gaudi::Algorithm`

ENDRELEASENOTES

The issue here was that not every check that is being done in `Writer.cpp` in k4FWCore is being done since the function there only looks at the names and makes the checks later, while here it is convenient to make the checks at the same time because it is expected this way in some parts of the wrapper (the if - else to check for `PodioDataSvc` or `IOSvc` are simpler this way).

Fix https://github.com/key4hep/k4MarlinWrapper/issues/219.