### PR TITLE
Use `IOSvc` by the default in docs and examples

### DIFF
--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -140,7 +140,7 @@ included with k4MarlinWrapper. Note that:
 
 - To run *clicReconstruction* with EDM4hep format, use the steering file found in the `examples` folder of k4MarlinWrapper:
 `k4MarlinWrapper/examples/clicRec_e4h_input.py` (this also gets installed to `$K4MARLINWRAPPER/examples` in Key4hep releases)
-  + Change the line where `evtsvc.input` is defined to point to the location of your input file.
+  + Change the line where `IOSvc.Input` is defined to point to the location of your input file.
   + At the bottom of the file, in the `ApplicationMgr` parameters, change `EvtMax   = 3,` to the number of events to run.
 
 This can be run in the following way.
@@ -149,7 +149,7 @@ cd CLICPerformance/clicConfig
 
 cp $K4MARLINWRAPPER/examples/clicRec_e4h_input.py .
 
-k4run clicRec_e4h_input.py --EventDataSvc.input ttbar_edm4hep.root
+k4run clicRec_e4h_input.py --IOSvc.Input ttbar_edm4hep.root
 ```
 
 ### DD4hep Geometry Information
@@ -163,16 +163,16 @@ In the space following
 
 ```python
 import os
-from Configurables import k4DataSvc, PodioInput
-evtsvc = k4DataSvc('EventDataSvc')
-evtsvc.input = os.path.join('$TEST_DIR/inputFiles/', os.environ.get("INPUTFILE", "ttbar_edm4hep.root"))
+from k4FWCore import IOSvc, ApplicationMgr
+io_svc = IOSvc()
+io_svc.Input = os.path.join('$TEST_DIR/inputFiles/', os.environ.get("INPUTFILE", "ttbar_edm4hep.root"))
 ```
 
 we can start the `svcList` list and add the `GeoSvc` and `TrackingCellIDEncodingSvc` with;
 
 ```python
 svcList = []
-svcList.append(evtsvc)
+svcList.append(io_svc)
 
 
 import os

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -40,7 +40,10 @@ CONSTANTS = {
 parseConstants(CONSTANTS)
 
 parser.add_argument(
-    "--iosvc", action="store_true", default=False, help="Use IOSvc instead of PodioDataSvc"
+    "--no-iosvc",
+    action="store_true",
+    default=False,
+    help="Use PodioDataSvc instead of IOSvc",
 )
 parser.add_argument(
     "--rec-output", default="Output_REC_e4h_input.slcio", help="Output file name for the REC file"
@@ -53,8 +56,7 @@ parser.add_argument(
 )
 
 args = parser.parse_known_args()[0]
-
-if args.iosvc:
+if not args.no_iosvc:
     evtsvc = EventDataSvc("EventDataSvc")
     iosvc = IOSvc()
     iosvc.Input = os.path.join(
@@ -2502,7 +2504,7 @@ algList.append(JetClusteringAndRefiner)
 algList.append(Output_REC)
 algList.append(Output_DST)
 
-if not args.iosvc:
+if args.no_iosvc:
     algList = [inp] + algList + [out]
 
 ApplicationMgr(TopAlg=algList, EvtSel="NONE", EvtMax=3, ExtSvc=[evtsvc], OutputLevel=WARNING)

--- a/k4MarlinWrapper/examples/clicRec_e4h_input.py
+++ b/k4MarlinWrapper/examples/clicRec_e4h_input.py
@@ -43,7 +43,7 @@ parser.add_argument(
     "--no-iosvc",
     action="store_true",
     default=False,
-    help="Use PodioDataSvc instead of IOSvc",
+    help="Use k4DataSvc instead of IOSvc",
 )
 parser.add_argument(
     "--rec-output", default="Output_REC_e4h_input.slcio", help="Output file name for the REC file"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,23 +100,38 @@ add_test( clic_geo_test ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/geoTest_
 
 # Test for checking whether the converters can resolve relations across
 # multiple processors
-ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --EventDataSvc.input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
-ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
-ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc_functional COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --use-functional-checker --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root})
-ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc_algorithm COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --use-gaudi-algorithm --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --IOSvc.Output=global_converter_maps_iosvc_algorithm.root)
-ExternalData_Add_Test( marlinwrapper_tests NAME global_converter_maps_iosvc_algorithm_functional COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --iosvc --use-gaudi-algorithm --use-functional-checker --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --IOSvc.Output=global_converter_maps_iosvc_algorithm_functional.root)
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME global_converter_maps
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --no-iosvc --EventDataSvc.input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+)
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME global_converter_maps_iosvc
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+)
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME global_converter_maps_iosvc_functional
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --use-functional-checker --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+)
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME global_converter_maps_iosvc_algorithm
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --use-gaudi-algorithm --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --IOSvc.Output=global_converter_maps_iosvc_algorithm.root
+)
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME global_converter_maps_iosvc_algorithm_functional
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --use-gaudi-algorithm --use-functional-checker --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --IOSvc.Output=global_converter_maps_iosvc_algorithm_functional.root
+)
 
 ExternalData_Add_Test( marlinwrapper_tests
   NAME link_conversion_edm4hep_to_lcio
-  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --no-iosvc --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )
 ExternalData_Add_Test( marlinwrapper_tests
   NAME link_conversion_edm4hep_to_lcio_iosvc
-  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --iosvc --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )
 ExternalData_Add_Test( marlinwrapper_tests
   NAME link_conversion_edm4hep_to_lcio_iosvc_gaudi_algorithm
-  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --iosvc --use-gaudi-algorithm --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_link_conversion_edm4hep.py --use-gaudi-algorithm --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )
 
 add_test( event_header_conversion bash -c "k4run ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/createEventHeader.py && anajob test.slcio | grep 'EVENT: 42'" )

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -39,7 +39,10 @@ from k4FWCore import ApplicationMgr, IOSvc
 from k4FWCore.parseArgs import parser
 
 parser.add_argument(
-    "--iosvc", action="store_true", default=False, help="Use IOSvc instead of PodioDataSvc"
+    "--no-iosvc",
+    action="store_true",
+    default=False,
+    help="Use PodioDataSvc instead of IOSvc",
 )
 parser.add_argument(
     "--use-functional-checker", action="store_true", default=False, help="Use functional checker"
@@ -56,12 +59,12 @@ args = parser.parse_known_args()[0]
 if args.use_functional_checker:
     from Configurables import MCRecoLinkCheckerFunctional as MCRecoLinkChecker
 
-if args.iosvc:
+if not args.no_iosvc:
     evtsvc = EventDataSvc("EventDataSvc")
 else:
     evtsvc = k4DataSvc("EventDataSvc")
 
-if args.iosvc:
+if not args.no_iosvc:
     iosvc = IOSvc()
     iosvc.CollectionNames = ["EventHeader", "MCParticles"]
     if not args.use_functional_checker:
@@ -127,7 +130,7 @@ algList = [
     mcLinkChecker,
 ]
 
-if not args.iosvc:
+if args.no_iosvc:
     algList = [podioInput] + algList + [podioOutput]
 
 ApplicationMgr(TopAlg=algList, EvtSel="NONE", EvtMax=1, ExtSvc=[evtsvc], OutputLevel=DEBUG)

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -42,7 +42,7 @@ parser.add_argument(
     "--no-iosvc",
     action="store_true",
     default=False,
-    help="Use PodioDataSvc instead of IOSvc",
+    help="Use k4DataSvc instead of IOSvc",
 )
 parser.add_argument(
     "--use-functional-checker", action="store_true", default=False, help="Use functional checker"

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -37,7 +37,10 @@ from k4FWCore.parseArgs import parser
 
 parser.add_argument("--inputfile", help="Input file")
 parser.add_argument(
-    "--iosvc", action="store_true", default=False, help="Use IOSvc instead of PodioDataSvc"
+    "--no-iosvc",
+    action="store_true",
+    default=False,
+    help="Use PodioDataSvc instead of IOSvc",
 )
 parser.add_argument(
     "--use-gaudi-algorithm",
@@ -47,7 +50,7 @@ parser.add_argument(
 )
 args = parser.parse_known_args()[0]
 
-if args.iosvc:
+if not args.no_iosvc:
     evtsvc = EventDataSvc("EventDataSvc")
     iosvc = IOSvc()
     iosvc.Input = args.inputfile
@@ -98,7 +101,7 @@ MarlinMCLinkChecker.EDM4hep2LcioTool = mcLinkConverter
 
 algList = [PseudoRecoAlg, MCRecoLinker, MarlinMCLinkChecker]
 
-if not args.iosvc:
+if args.no_iosvc:
     algList = [podioInput] + algList
 
 ApplicationMgr(

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -40,7 +40,7 @@ parser.add_argument(
     "--no-iosvc",
     action="store_true",
     default=False,
-    help="Use PodioDataSvc instead of IOSvc",
+    help="Use k4DataSvc instead of IOSvc",
 )
 parser.add_argument(
     "--use-gaudi-algorithm",

--- a/test/scripts/clicRec_e4h_input.sh
+++ b/test/scripts/clicRec_e4h_input.sh
@@ -26,11 +26,11 @@ cd CLICPerformance/clicConfig
 if [ "$2" = "--iosvc" ]; then
   iosvc="_iosvc"
   echo "Running with IO service"
-  file_arg="--iosvc --IOSvc.Input=$1"
+  file_arg="--IOSvc.Input=$1"
 elif [ "$2" = "--no-iosvc" ]; then
   iosvc=""
   echo "Running without IO service"
-  file_arg="--EventDataSvc.input=$1"
+  file_arg="--no-iosvc --EventDataSvc.input=$1"
 else
   echo "Wrong argument $2"
   return 1


### PR DESCRIPTION
BEGINRELEASENOTES
- Update docs to use `IOSvc` instead of `k4DataSvc`. Use`IOSvc` by the default in the examples

ENDRELEASENOTES

Changing `IOSvc` from opt-in to opt-out as it's supposed to be the recommended service with the upcoming deprecation of `PodioDataSvc`. https://github.com/key4hep/k4FWCore/issues/292

The instructions in the docs are updated to work with `IOSvc`