### PR TITLE
Update converter script to use f-strings and properly handle empty parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,5 +32,5 @@ repos:
         "-o", "Key4hep-Project",
         "-n", "Key4hep",
         "-u", "https://key4hep.github.io/key4hep-doc/",
-        "-x", ".github/*", ".pre-commit-config.yaml", "README.md", "doc/ReleaseNotes.md", ".clang-format",
+        "-x", ".github/*", ".pre-commit-config.yaml", "README.md", "doc/ReleaseNotes.md", ".clang-format", "test/marlin_steering/MarlinWithEmptyParameter.xml",
         "-f",]

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -72,7 +72,7 @@ def replaceConstants(value, constants):
     for val in split_values:
         captured_patterns = re.findall("\$\{\w*\}", val)
         if not captured_patterns:
-            formatted_array.append('"{}"'.format(val))
+            formatted_array.append(f'"{val}"')
         elif captured_patterns:
             val_format = re.sub(r"\$\{(\w*)\}", r"%(\1)s", val)
             val_format = f'"{val_format}" % CONSTANTS'
@@ -100,25 +100,23 @@ def convertConstants(lines, tree):
             for pattern in captured_patterns:
                 # replace every ${constant} for %(constant)s
                 constants[key] = re.sub(r"\$\{(\w*)\}", r"%(\1)s", constants[key])
-            constants[key] = '"{}"'.format(constants[key])
+            constants[key] = f'"{constants[key]}"'
         elif len(split_values) > 1:
             for val in split_values:
                 # capture all ${constant}
                 captured_patterns = re.findall("\$\{\w*\}", val)
                 if len(captured_patterns) == 0:
-                    formatted_array.append('"{}"'.format(val))
+                    formatted_array.append('"{val}"')
                 elif len(captured_patterns) >= 1:
                     # replace every ${constant} for %(constant)s
                     val_format = re.sub(r"\$\{(\w*)\}", r"%(\1)s", val)
-                    val_format = '"{}"'.format(val_format)
+                    val_format = '"{val_format}"'
                     formatted_array.append(val_format)
-            constants[key] = "[{}]".format(", ".join(formatted_array))
+            constants[key] = f'[{", ".join(formatted_array)}]'
 
     lines.append("\nCONSTANTS = {")
     for key in constants:
-        lines.append(
-            " " * len("CONSTANTS = {") + "'{}': {},".format(key, constants[key])
-        )
+        lines.append(f'    "{key}": {constants[key]},')
     lines.append("}\n")
 
     lines.append("parseConstants(CONSTANTS)\n")

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -239,7 +239,7 @@ def convertParameters(params, proc, globParams, constants):
             lines.append(f'    "{para}": [{replaceConstants(value, constants)}],')
 
     lines[-1] = lines[-1][:-1]
-    lines.append("    }\n")
+    lines.append("}\n")
     return lines
 
 

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -96,20 +96,20 @@ def convertConstants(lines, tree):
         formatted_array = []
         split_values = value.split()
         if len(split_values) == 1:
-            """ capture all ${constant} """
+            # capture all ${constant}
             captured_patterns = re.findall("\$\{\w*\}", value)
             for pattern in captured_patterns:
-                """ replace every ${constant} for %(constant)s """
+                # replace every ${constant} for %(constant)s
                 constants[key] = re.sub(r"\$\{(\w*)\}", r"%(\1)s", constants[key])
             constants[key] = '"{}"'.format(constants[key])
         elif len(split_values) > 1:
             for val in split_values:
-                """ capture all ${constant} """
+                # capture all ${constant}
                 captured_patterns = re.findall("\$\{\w*\}", val)
                 if len(captured_patterns) == 0:
                     formatted_array.append('"{}"'.format(val))
                 elif len(captured_patterns) >= 1:
-                    """ replace every ${constant} for %(constant)s """
+                    # replace every ${constant} for %(constant)s
                     val_format = re.sub(r"\$\{(\w*)\}", r"%(\1)s", val)
                     val_format = '"{}"'.format(val_format)
                     formatted_array.append(val_format)

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -227,7 +227,6 @@ def verbosityTranslator(marlinLogLevel):
 def convertParameters(params, proc, globParams, constants):
     """convert json of parameters to Gaudi"""
     lines = []
-    proc = proc.replace(".", "_")
     if "Verbosity" in params:
         lines.append(f"{proc}.OutputLevel = {verbosityTranslator(params['Verbosity'])}")
 
@@ -250,7 +249,7 @@ def convertProcessors(lines, tree, globParams, constants):
     for proc in processors:
         proc_name = proc.replace(".", "_")
         lines.append(f'{proc_name} = MarlinProcessorWrapper("{proc}")')
-        lines += convertParameters(processors[proc], proc, globParams, constants)
+        lines += convertParameters(processors[proc], proc_name, globParams, constants)
     return lines
 
 

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -17,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import absolute_import, unicode_literals, print_function
 
 from copy import deepcopy
 import re

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -238,7 +238,6 @@ def convertParameters(params, proc, globParams, constants):
             value = " ".join(value.split())
             lines.append(f'    "{para}": [{replaceConstants(value, constants)}],')
 
-    lines[-1] = lines[-1][:-1]
     lines.append("}\n")
     return lines
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,10 @@ ExternalData_Add_Test( marlinwrapper_tests NAME simple_processors COMMAND ${K4RU
 # Test simple_processors2
 ExternalData_Add_Test( marlinwrapper_tests NAME simple_processors2 COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/simple_processors2.py --LcioEvent.Files DATA{${PROJECT_SOURCE_DIR}/test/input_files/testSimulation.slcio})
 
+ExternalData_Add_Test( marlinwraper_tests NAME convert_empty_parameters
+  COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/convert_empty_parameters.sh DATA{${PROJECT_SOURCE_DIR}/test/input_files/testSimulation.slcio}"
+)
+
 # CLICPerformance setup is added as a simple test that will always succeed, on
 # which other tests that need it can depend, in order to make concurrent
 # running of those more easily possible

--- a/test/marlin_steering/MarlinWithEmptyParameter.xml
+++ b/test/marlin_steering/MarlinWithEmptyParameter.xml
@@ -1,0 +1,22 @@
+<marlin>
+    <constants>
+    </constants>
+
+    <execute>
+        <processor name="MyStatusMonitor" />
+    </execute>
+
+    <global>
+        <parameter name="LCIOInputFiles">
+            filename.slcio
+        </parameter>
+        <parameter name="MaxRecordNumber" value="0"/>
+        <parameter name="SkipNEvents" value="0"/>
+        <parameter name="SupressCheck" value="false"/>
+        <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+        <parameter name="RandomSeed" value="1234567890" />
+    </global>
+
+    <processor name="MyStatusMonitor" type="Statusmonitor"/>
+
+</marlin>

--- a/test/scripts/convert_empty_parameters.sh
+++ b/test/scripts/convert_empty_parameters.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+##
+## Copyright (c) 2019-2024 Key4hep-Project.
+##
+## This file is part of Key4hep.
+## See https://key4hep.github.io/key4hep-doc/ for further info.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -eu
+
+python \
+  $TEST_DIR/../k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py \
+  $TEST_DIR/marlin_steering/MarlinWithEmptyParameter.xml \
+  GaudiWithEmptyParameter.py
+
+k4run GaudiWithEmptyParameter.py --LcioEvent.Files="${1}"


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to f-strings for formatting strings in the steering file converter script
- Remove python2 compatibility
- Fix erroneous removal of opening `{` when the parameters of a Marlin Processor are empty (see #222)

ENDRELEASENOTES

Fixes #222 
