### PR TITLE
Make sure to read the EventHeader collection

### DIFF
--- a/doc/MarlinWrapperIntroduction.md
+++ b/doc/MarlinWrapperIntroduction.md
@@ -221,6 +221,12 @@ lcio2edm4hepConv = Lcio2EDM4hepTool("Lcio2EDM4hep")
 lcio2edm4hepConv.collNameMapping = {"MCParticle": "MCParticles"}
 ```
 
+```{note}
+The `"EventHeader"` collection will be added to the collections to convert
+unconditionally. Hence, if it's missing the conversion will fail. Make sure to
+read it in, or create it on the fly.
+```
+
 ## Potential pitfalls when using other Gaudi Algorithms
 
 Although mixing wrapped Marlin Processors with other Gaudi Algorithms is working

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -56,13 +56,14 @@ else:
 
 if args.iosvc:
     iosvc = IOSvc()
+    iosvc.CollectionNames = ["EventHeader", "MCParticles"]
     if not args.use_functional_checker:
         iosvc.Output = "global_converter_maps_iosvc.root"
     else:
         iosvc.Output = "global_converter_maps_iosvc_functional.root"
 else:
     podioInput = PodioInput("InputReader")
-    podioInput.collections = ["MCParticles"]
+    podioInput.collections = ["EventHeader", "MCParticles"]
     podioInput.OutputLevel = INFO
     podioOutput = PodioOutput("OutputWriter")
     podioOutput.filename = "global_converter_maps.root"

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -44,11 +44,12 @@ if args.iosvc:
     evtsvc = EventDataSvc("EventDataSvc")
     iosvc = IOSvc()
     iosvc.Input = args.inputfile
+    iosvc.CollectionNames = ["EventHeader", "MCParticles"]
 else:
     evtsvc = k4DataSvc("EventDataSvc")
     evtsvc.input = args.inputfile
     podioInput = PodioInput("InputReader")
-    podioInput.collections = ["MCParticles"]
+    podioInput.collections = ["EventHeader", "MCParticles"]
     podioInput.OutputLevel = INFO
 
 


### PR DESCRIPTION


BEGINRELEASENOTES
- Make sure to read the `"EventHeader"` collection in the tests as it will be converted unconditionally and lead to termination if it's not found.

ENDRELEASENOTES

This has been uncovered by merging https://github.com/key4hep/k4FWCore/pull/290
