### PR TITLE
Replace InitDD4hep processor with Gaudi services during steering file conversion

### DIFF
--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -33,6 +33,7 @@ jobs:
         export LD_LIBRARY_PATH=/Package/install/lib64:$LD_LIBRARY_PATH
         export PYTHONPATH=/Package/install/python:$PYTHONPATH
         export K4MARLINWRAPPER=/Package/install/share/k4MarlinWrapper
+        export PATH=/Package/install/bin:$PATH
         unset KEY4HEP_STACK;
         mkdir testdir;
         cat .github/scripts/yamlheader.md  ${{ matrix.PAGE }}.md > testdir/test.md;

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -158,7 +158,7 @@ The `MarlinDD4hep::InitializeDD4hep` processor can be replaced by the `k4SimGean
 This requires removing the wrapped `InitDD4hep` processor from the `algList` and the two new processed be appended to the `ExtSvc` argument in the `ApplicationMgr`.
 
 ```{note}
-If you are using a version of `k4MarlinWrapper` that is newer than `v00-11` then this replacement will be done automatically by the `convertMarlinSteeringToGaudi.py` script.
+If you are using a version of `k4MarlinWrapper` that is newer than `v00-11` (April 2025) this replacement will be done automatically by the `convertMarlinSteeringToGaudi.py` script.
 ```
 
 We will create another list, `svcList` for this.

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -100,9 +100,9 @@ during [Simulation](#simulation).
 #### Reconstruction with LCIO input
 
 - When using **LCIO** format for the input events to be used in reconstruction:
-  + Modify the ``clicReconstruction.py`` file to point to the ``ttbar.slcio`` input file, and change the
-  ``DD4hepXMLFile`` parameter for the ``InitDD4hep`` algorithm.  In addition the two processors with the comment ``#
-  Config.OverlayFalse`` and ``# Config.TrackingConformal`` should be enabled by uncommenting their line in the ``algList``
+  + Modify the `clicReconstruction.py` file to point to the `ttbar.slcio` input file, and change the
+  `converters` parameter for the `geoSvc` service.  In addition the two processors with the comment `#
+  Config.OverlayFalse` and `# Config.TrackingConformal` should be enabled by uncommenting their line in the `algList`
   at the end of the file.
 
 ```bash
@@ -116,8 +116,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile": \[".*"\],; "DD4hepXMLFile": \[os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\],;' clicReconstruction.py
-
+sed -i 's;geoSvc.detectors = \[".*"\];geoSvc.detectors = \[os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\];' clicReconstruction.py
 ```
 
 Then the reconstruction using the k4MarlinWrapper can be run with
@@ -154,9 +153,13 @@ k4run clicRec_e4h_input.py --IOSvc.Input ttbar_edm4hep.root
 
 ### DD4hep Geometry Information
 
-The ``MarlinDD4hep::InitializeDD4hep`` processor can be replaced by the ``k4SimGeant4::GeoSvc`` and the
-``TrackingCellIDEncodingSvc`` the latter of which is part of the k4MarlinWrapper repository.
+The `MarlinDD4hep::InitializeDD4hep` processor can be replaced by the `k4SimGeant4::GeoSvc` and the
+`TrackingCellIDEncodingSvc` the latter of which is part of the k4MarlinWrapper repository.
 This requires removing the wrapped `InitDD4hep` processor from the `algList` and the two new processed be appended to the `ExtSvc` argument in the `ApplicationMgr`.
+
+```{note}
+If you are using a version of `k4MarlinWrapper` that is newer than `v00-11` then this replacement will be done automatically by the `convertMarlinSteeringToGaudi.py` script.
+```
 
 We will create another list, `svcList` for this.
 In the space following

--- a/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+++ b/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
@@ -101,7 +101,7 @@ during [Simulation](#simulation).
 
 - When using **LCIO** format for the input events to be used in reconstruction:
   + Modify the `clicReconstruction.py` file to point to the `ttbar.slcio` input file, and change the
-  `converters` parameter for the `geoSvc` service.  In addition the two processors with the comment `#
+  `detectors` parameter for the `geoSvc` service.  In addition the two processors with the comment `#
   Config.OverlayFalse` and `# Config.TrackingConformal` should be enabled by uncommenting their line in the `algList`
   at the end of the file.
 

--- a/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/k4MarlinWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -112,7 +112,7 @@ def convertConstants(lines, tree):
                     val_format = re.sub(r"\$\{(\w*)\}", r"%(\1)s", val)
                     val_format = '"{val_format}"'
                     formatted_array.append(val_format)
-            constants[key] = f'[{", ".join(formatted_array)}]'
+            constants[key] = f"[{', '.join(formatted_array)}]"
 
     lines.append("\nCONSTANTS = {")
     for key in constants:
@@ -182,14 +182,15 @@ def createHeader(lines):
     lines.append("from Configurables import LcioEvent, EventDataSvc, MarlinProcessorWrapper")
     lines.append("from k4MarlinWrapper.parseConstants import *")
     lines.append("algList = []")
+    lines.append("svcList = []")
     lines.append("evtsvc = EventDataSvc()\n")
-    # lines.append("END_TAG = \"END_TAG\"\n")
+    lines.append("svcList.append(evtsvc)")
 
 
 def createLcioReader(lines, glob):
     lines.append("read = LcioEvent()")
     lines.append(f"read.OutputLevel = {verbosityTranslator(glob.get('Verbosity', 'DEBUG'))}")
-    lines.append(f"read.Files = [\"{glob.get('LCIOInputFiles')}\"]")
+    lines.append(f'read.Files = ["{glob.get("LCIOInputFiles")}"]')
     lines.append("algList.append(read)\n")
 
 
@@ -198,7 +199,7 @@ def createFooter(lines, glob):
     lines.append("ApplicationMgr( TopAlg = algList,")
     lines.append("                EvtSel = 'NONE',")
     lines.append("                EvtMax   = 10,")
-    lines.append("                ExtSvc = [evtsvc],")
+    lines.append("                ExtSvc = svcList,")
     lines.append(
         f"                OutputLevel={verbosityTranslator(glob.get('Verbosity', 'DEBUG'))}"
     )
@@ -228,7 +229,7 @@ def convertParameters(params, proc, globParams, constants):
     if "Verbosity" in params:
         lines.append(f"{proc}.OutputLevel = {verbosityTranslator(params['Verbosity'])}")
 
-    lines.append(f"{proc}.ProcessorType = \"{params.get('type')}\"")
+    lines.append(f'{proc}.ProcessorType = "{params.get("type")}"')
     lines.append(f"{proc}.Parameters = {{")
     for para in sorted(params):
         if para not in ["type", "Verbosity"]:

--- a/test/scripts/clicRec.sh
+++ b/test/scripts/clicRec.sh
@@ -40,7 +40,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile": \[".*"\],; "DD4hepXMLFile": \[os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\],;' clicReconstruction.py
+sed -i 's;geoSvc.detectors = \[".*"\];geoSvc.detectors = \[os.environ["K4GEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml"\];' clicReconstruction.py
 # Change output level for correct test confirmation
 sed -i 's;OutputLevel=WARNING; OutputLevel=DEBUG;' clicReconstruction.py
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Replace instances of `InitializeDD4hep` processors with `GeoSvc` and `TrackingCellIDEncodingSvc` (if necessary) in the conversion of Marlin steering files to Gaudi options files.

ENDRELEASENOTES

Closes #151 
