### PR TITLE
Ensure that all EDM4hep collections are discovered for conversion

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -28,6 +28,7 @@
 
 #include <map>
 #include <string>
+#include <tuple>
 #include <vector>
 
 class PodioDataSvc;
@@ -70,9 +71,9 @@ private:
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   // Metadata service from k4FWCore that is used together with IOSvc
   SmartIF<IMetadataSvc> m_metadataSvc;
-  /// A (caching) map of original to new collection names that will be populated
+  /// A (caching) "map" of original to new collection names that will be populated
   /// during the first conversion
-  std::unordered_map<std::string, std::string> m_collsToConvert{};
+  std::vector<std::tuple<std::string, std::string>> m_collsToConvert{};
   std::map<uint32_t, std::string> m_idToName;
 
   void convertTracks(TrackMap& tracks_vec, const std::string& e4h_coll_name, const std::string& lcio_coll_name,

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -70,7 +70,9 @@ private:
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   // Metadata service from k4FWCore that is used together with IOSvc
   SmartIF<IMetadataSvc> m_metadataSvc;
-  std::vector<std::string> m_collectionNames;
+  /// A (caching) map of original to new collection names that will be populated
+  /// during the first conversion
+  std::unordered_map<std::string, std::string> m_collsToConvert{};
   std::map<uint32_t, std::string> m_idToName;
 
   void convertTracks(TrackMap& tracks_vec, const std::string& e4h_coll_name, const std::string& lcio_coll_name,

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -398,14 +398,15 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
       info() << "Converting all collections from EDM4hep to LCIO" << endmsg;
       std::vector<std::string> collectionNames{};
       if (m_podioDataSvc) {
+        // If we have the PodioDataSvc get the collections available from frame
         edmEvent = m_podioDataSvc->getEventFrame();
         collectionNames = edmEvent.value().get().getAvailableCollections();
-      } else {
-        std::optional<std::map<uint32_t, std::string>> idToNameOpt(std::move(m_idToName));
-        auto collections = getAvailableCollectionsFromStore(this, idToNameOpt);
-        m_idToName = std::move(idToNameOpt.value());
-        collectionNames.insert(collectionNames.end(), collections.begin(), collections.end());
       }
+      // Always check the contents of the TES
+      std::optional<std::map<uint32_t, std::string>> idToNameOpt(std::move(m_idToName));
+      auto collections = getAvailableCollectionsFromStore(this, idToNameOpt);
+      m_idToName = std::move(idToNameOpt.value());
+      collectionNames.insert(collectionNames.end(), collections.begin(), collections.end());
 
       // And simply add the rest, exploiting the fact that emplace will not
       // replace existing entries with the same key

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -386,25 +386,32 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
 // Use the collection names in the parameters to read and write them
 StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   std::optional<std::reference_wrapper<const podio::Frame>> edmEvent;
-  if (m_collectionNames.empty() && m_podioDataSvc) {
-    edmEvent = m_podioDataSvc->getEventFrame();
-    m_collectionNames = edmEvent.value().get().getAvailableCollections();
-  } else if (m_collectionNames.empty()) {
-    std::optional<std::map<uint32_t, std::string>> idToNameOpt(std::move(m_idToName));
-    auto collections = getAvailableCollectionsFromStore(this, idToNameOpt);
-    m_idToName = std::move(idToNameOpt.value());
-    m_collectionNames.insert(m_collectionNames.end(), collections.begin(), collections.end());
-  }
-  // Start off with the pre-defined collection name mappings
-  auto collsToConvert{m_collNames.value()};
-  // We *always* want to convert the EventHeader
-  collsToConvert.emplace(edm4hep::labels::EventHeader, "<directly into LCEvent>");
-  if (m_convertAll) {
-    info() << "Converting all collections from EDM4hep to LCIO" << endmsg;
-    // And simply add the rest, exploiting the fact that emplace will not
-    // replace existing entries with the same key
-    for (const auto& name : m_collectionNames) {
-      collsToConvert.emplace(name, name);
+  // use m_collsToConvert to detect whether we run the first time and cache the
+  // results as we can assume that all the events have the same contents
+  if (m_collsToConvert.empty()) {
+    // Start off with the pre-defined collection name mappings
+    m_collsToConvert = {m_collNames.value().begin(), m_collNames.value().end()};
+    // We *always* want to convert the EventHeader
+    m_collsToConvert.emplace(edm4hep::labels::EventHeader, "<directly into LCEvent>");
+
+    if (m_convertAll) {
+      info() << "Converting all collections from EDM4hep to LCIO" << endmsg;
+      std::vector<std::string> collectionNames{};
+      if (m_podioDataSvc) {
+        edmEvent = m_podioDataSvc->getEventFrame();
+        collectionNames = edmEvent.value().get().getAvailableCollections();
+      } else {
+        std::optional<std::map<uint32_t, std::string>> idToNameOpt(std::move(m_idToName));
+        auto collections = getAvailableCollectionsFromStore(this, idToNameOpt);
+        m_idToName = std::move(idToNameOpt.value());
+        collectionNames.insert(collectionNames.end(), collections.begin(), collections.end());
+      }
+
+      // And simply add the rest, exploiting the fact that emplace will not
+      // replace existing entries with the same key
+      for (const auto& name : collectionNames) {
+        m_collsToConvert.emplace(name, name);
+      }
     }
   }
 
@@ -414,7 +421,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
 
   std::vector<std::tuple<std::string, const podio::CollectionBase*>> linkCollections{};
 
-  for (const auto& [edm4hepName, lcioName] : collsToConvert) {
+  for (const auto& [edm4hepName, lcioName] : m_collsToConvert) {
     const auto coll = getEDM4hepCollection(edm4hepName);
     if (coll->getTypeName().find("LinkCollection") != std::string_view::npos) {
       debug() << edm4hepName << " is a link collection, converting it later" << endmsg;

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -406,7 +406,9 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
           debug() << fmt::format("Adding '{}' from Frame to conversion? {}", name, inserted);
         }
       }
-      // Always check the contents of the TES
+      // Always check the contents of the TES because algorithms that do not use
+      // the PodioDataSvc (e.g. all Functional ones) go to the TES directly and
+      // the PodioDataSvc Frame doesn't now about them.
       std::optional<std::map<uint32_t, std::string>> idToNameOpt(std::move(m_idToName));
       for (const auto& name : getAvailableCollectionsFromStore(this, idToNameOpt)) {
         const auto& [_, inserted] = collNameMapping.emplace(name, name);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,6 +105,11 @@ ExternalData_Add_Test( marlinwrapper_tests
   COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --no-iosvc --EventDataSvc.input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )
 ExternalData_Add_Test( marlinwrapper_tests
+  NAME global_converter_maps_algorithm
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --no-iosvc --use-gaudi-algorithm --OutputWriter.filename=global_converter_maps_algorithm.root --EventDataSvc.input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+)
+
+ExternalData_Add_Test( marlinwrapper_tests
   NAME global_converter_maps_iosvc
   COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_global_converter_maps.py --IOSvc.Input DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )

--- a/test/gaudi_opts/test_global_converter_maps.py
+++ b/test/gaudi_opts/test_global_converter_maps.py
@@ -90,11 +90,7 @@ else:
     )
 
 inputConverter = EDM4hep2LcioTool("InputConverter")
-inputConverter.convertAll = False
-inputConverter.collNameMapping = {
-    "MCParticles": "MCParticles",
-    "PseudoRecoParticles": "PseudoRecoParticles",
-}
+inputConverter.convertAll = True
 inputConverter.OutputLevel = DEBUG
 
 TrivialMCTruthLinkerProc = MarlinProcessorWrapper("TrivialMCTruthLinker")
@@ -108,8 +104,7 @@ TrivialMCTruthLinkerProc.Parameters = {
 TrivialMCTruthLinkerProc.EDM4hep2LcioTool = inputConverter
 
 mcTruthConverter = Lcio2EDM4hepTool("TrivialMCTruthLinkerConverter")
-mcTruthConverter.convertAll = False
-mcTruthConverter.collNameMapping = {"TrivialMCRecoLinks": "TrivialMCRecoLinks"}
+mcTruthConverter.convertAll = True
 mcTruthConverter.OutputLevel = DEBUG
 
 TrivialMCTruthLinkerProc.Lcio2EDM4hepTool = mcTruthConverter


### PR DESCRIPTION
Add a new test case to showcase all possible behaviors


BEGINRELEASENOTES
- Unconditionally check the TES when looking for EDM4hep collections to convert in case `convertAll` is set to `True`.
- Restructure conversion slightly and only do this lookup once and cache the results from the first conversion. This is possible since event contents are assumed to be constant.

ENDRELEASENOTES


~This is a draft PR to showcase the behavior in https://github.com/key4hep/k4MarlinWrapper/issues/226#issuecomment-2714564618~