### PR TITLE
[WiP] Make sure to always only have valid collection names

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 class IDataProviderSvc;
@@ -67,7 +68,8 @@ private:
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   /// A (caching) "map" of original to new collection names that will be populated
   /// during the first conversion
-  std::vector<std::tuple<std::string, std::string>> m_collsToConvert{};
+  // std::vector<std::tuple<std::string, std::string>> m_collsToConvert{};
+  std::unordered_map<std::string, std::string> m_collsToConvert{};
   std::map<uint32_t, std::string> m_idToName;
 
   void convertTracks(TrackMap& tracks_vec, const std::string& e4h_coll_name, const std::string& lcio_coll_name,

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -68,7 +68,6 @@ private:
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   /// A (caching) "map" of original to new collection names that will be populated
   /// during the first conversion
-  // std::vector<std::tuple<std::string, std::string>> m_collsToConvert{};
   std::unordered_map<std::string, std::string> m_collsToConvert{};
   std::map<uint32_t, std::string> m_idToName;
 

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -28,7 +28,6 @@
 
 #include <map>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -104,7 +103,8 @@ private:
   void convertReconstructedParticles(RecoParticleMap& recoparticles_vec, const std::string& e4h_coll_name,
                                      const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);
 
-  void convertParticleIDs(ParticleIDMap& pidMap, const std::string& e4h_coll_name, int32_t algoId);
+  void convertParticleIDs(ParticleIDMap& pidMap, std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
+                          lcio::LCEventImpl* lcio_event, const podio::Frame& edmEvent);
 
   void convertMCParticles(MCParticleMap& mc_particles_vec, const std::string& e4h_coll_name,
                           const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -103,8 +103,7 @@ private:
   void convertReconstructedParticles(RecoParticleMap& recoparticles_vec, const std::string& e4h_coll_name,
                                      const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);
 
-  void convertParticleIDs(ParticleIDMap& pidMap, std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
-                          lcio::LCEventImpl* lcio_event, const podio::Frame& edmEvent);
+  void convertParticleIDs(ParticleIDMap& pidMap, const std::string& e4h_coll_name, int32_t algoId);
 
   void convertMCParticles(MCParticleMap& mc_particles_vec, const std::string& e4h_coll_name,
                           const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event);

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -32,10 +32,12 @@
 #include "GaudiKernel/IDataManagerSvc.h"
 #include "GaudiKernel/IDataProviderSvc.h"
 
+#include <IMPL/LCEventImpl.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <functional>
+#include <k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h>
 #include <memory>
 
 DECLARE_COMPONENT(EDM4hep2LcioTool);
@@ -107,10 +109,17 @@ void EDM4hep2LcioTool::convertTrackerHits(TrackerHitMap& trackerhits_vec, const 
   lcio_event->addCollection(conv_trackerhits.release(), lcio_coll_name);
 }
 
-void EDM4hep2LcioTool::convertParticleIDs(ParticleIDMap& pidMap, const std::string& e4h_coll_name, int32_t algoId) {
-  k4FWCore::DataHandle<edm4hep::ParticleIDCollection> pidHandle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+void EDM4hep2LcioTool::convertParticleIDs(ParticleIDMap& pidMap,
+                                          std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
+                                          lcio::LCEventImpl* lcio_event, const podio::Frame& edmEvent) {
 
-  EDM4hep2LCIOConv::convertParticleIDs(pidHandle.get(), pidMap, algoId);
+  EDM4hep2LCIOConv::sortParticleIDs(pidCollections);
+  for (const auto& pidCollMeta : pidCollections) {
+    DataHandle<edm4hep::ParticleIDCollection> pidHandle{pidCollMeta.name, Gaudi::DataHandle::Reader, this};
+
+    auto algoId = attacheParticleIDMetaInfo(pidCollMeta, lcio_event, edmEvent);
+    EDM4hep2LCIOConv::convertParticleIDs(pidHandle.get(), pidMap, algoId.value_or(-1));
+  }
 }
 
 void EDM4hep2LcioTool::convertTrackerHitPlanes(TrackerHitPlaneMap& trackerhits_vec, const std::string& e4h_coll_name,

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -432,10 +432,16 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
       // Check if we can figure out the collection from information on the TES
       if (!pidCollMeta.coll->empty()) {
         const auto id = (*pidCollMeta.coll)[0].getParticle().id().collectionID;
-        if (auto it = m_idToName.find(id); it != m_idToName.end()) {
-          auto name = it->second;
+        debug() << fmt::format(
+                       "Using {:0>8x} as collection id to lookup LCIO collection for attaching ParticleID metadata", id)
+                << endmsg;
+        if (const auto it = m_idToName.find(id); it != m_idToName.end()) {
+          const auto& name = it->second;
+          debug() << "Corresponding name in EDM4hep is: " << name << endmsg;
           if (pidCollMeta.metadata.has_value()) {
-            UTIL::PIDHandler pidHandler(lcio_event->getCollection(name));
+            const auto lcioColl = lcio_event->getCollection(name);
+            debug() << "LCIO collection has type: " << lcioColl->getTypeName() << endmsg;
+            UTIL::PIDHandler pidHandler(lcioColl);
             algoId =
                 pidHandler.addAlgorithm(pidCollMeta.metadata.value().algoName, pidCollMeta.metadata.value().paramNames);
           }

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -109,17 +109,10 @@ void EDM4hep2LcioTool::convertTrackerHits(TrackerHitMap& trackerhits_vec, const 
   lcio_event->addCollection(conv_trackerhits.release(), lcio_coll_name);
 }
 
-void EDM4hep2LcioTool::convertParticleIDs(ParticleIDMap& pidMap,
-                                          std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
-                                          lcio::LCEventImpl* lcio_event, const podio::Frame& edmEvent) {
+void EDM4hep2LcioTool::convertParticleIDs(ParticleIDMap& pidMap, const std::string& e4h_coll_name, int32_t algoId) {
+  k4FWCore::DataHandle<edm4hep::ParticleIDCollection> pidHandle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
 
-  EDM4hep2LCIOConv::sortParticleIDs(pidCollections);
-  for (const auto& pidCollMeta : pidCollections) {
-    DataHandle<edm4hep::ParticleIDCollection> pidHandle{pidCollMeta.name, Gaudi::DataHandle::Reader, this};
-
-    auto algoId = attacheParticleIDMetaInfo(pidCollMeta, lcio_event, edmEvent);
-    EDM4hep2LCIOConv::convertParticleIDs(pidHandle.get(), pidMap, algoId.value_or(-1));
-  }
+  EDM4hep2LCIOConv::convertParticleIDs(pidHandle.get(), pidMap, algoId);
 }
 
 void EDM4hep2LcioTool::convertTrackerHitPlanes(TrackerHitPlaneMap& trackerhits_vec, const std::string& e4h_coll_name,

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -363,10 +363,8 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
             << "SimCalorimeterHit collection to be converted in order to be able to attach to them" << endmsg;
   } else {
     warning() << "Error trying to convert requested " << fulltype << " with name " << e4h_coll_name << endmsg;
-    warning() << "List of supported types: "
-              << "Track, TrackerHit3D, TrackerHitPlane, SimTrackerHit, "
-              << "Cluster, CalorimeterHit, RawCalorimeterHit, "
-              << "SimCalorimeterHit, Vertex, ReconstructedParticle, "
+    warning() << "List of supported types: " << "Track, TrackerHit3D, TrackerHitPlane, SimTrackerHit, "
+              << "Cluster, CalorimeterHit, RawCalorimeterHit, " << "SimCalorimeterHit, Vertex, ReconstructedParticle, "
               << "MCParticle." << endmsg;
   }
 }
@@ -385,7 +383,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
     // We *always* want to convert the EventHeader (iff it's available)
     if (getEDM4hepCollection(edm4hep::labels::EventHeader, true)) {
       debug() << edm4hep::labels::EventHeader << " collection available. Converting it." << endmsg;
-      m_collsToConvert.emplace_back(edm4hep::labels::EventHeader, "<directly into LCEvent>");
+      m_collsToConvert.emplace(edm4hep::labels::EventHeader, "<directly into LCEvent>");
     } else {
       info() << "The " << edm4hep::labels::EventHeader << " collection is not available. Not converting it." << endmsg;
     }
@@ -400,7 +398,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
       m_idToName = std::move(idToNameOpt.value());
     }
     for (auto&& [origName, newName] : collNameMapping) {
-      m_collsToConvert.emplace_back(std::move(origName), std::move(newName));
+      m_collsToConvert.emplace(std::move(origName), std::move(newName));
     }
   }
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -367,9 +367,9 @@ void EDM4hep2LcioTool::convertAdd(const std::string& e4h_coll_name, const std::s
             << "SimCalorimeterHit collection to be converted in order to be able to attach to them" << endmsg;
   } else {
     warning() << "Error trying to convert requested " << fulltype << " with name " << e4h_coll_name << endmsg;
-    warning() << "List of supported types: " << "Track, TrackerHit3D, TrackerHitPlane, SimTrackerHit, "
-              << "Cluster, CalorimeterHit, RawCalorimeterHit, " << "SimCalorimeterHit, Vertex, ReconstructedParticle, "
-              << "MCParticle." << endmsg;
+    warning() << "List of supported types: Track, TrackerHit3D, TrackerHitPlane, SimTrackerHit, Cluster, "
+              << "CalorimeterHit, RawCalorimeterHit, SimCalorimeterHit, Vertex, ReconstructedParticle, MCParticle."
+              << endmsg;
   }
 }
 

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -32,6 +32,10 @@
 #include "GaudiKernel/IDataManagerSvc.h"
 #include "GaudiKernel/IDataProviderSvc.h"
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <functional>
 #include <memory>
 
 DECLARE_COMPONENT(EDM4hep2LcioTool);
@@ -425,7 +429,6 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   debug() << "Event: " << lcio_event->getEventNumber() << " Run: " << lcio_event->getRunNumber() << endmsg;
 
   EDM4hep2LCIOConv::sortParticleIDs(pidCollections);
-
   for (const auto& pidCollMeta : pidCollections) {
     auto algoId = attachParticleIDMetaData(lcio_event, edmEvent, pidCollMeta);
     if (!algoId.has_value()) {
@@ -454,6 +457,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
                   << endmsg;
       }
     }
+
     convertParticleIDs(collection_pairs.particleIDs, pidCollMeta.name, algoId.value_or(-1));
   }
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -83,9 +83,6 @@ void Lcio2EDM4hepTool::registerCollection(
   auto wrapper = new AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>(std::move(e4hColl));
   // No need to check for pre-existing collections, since we only ever end up
   // here if that is not the case
-  // NOTE: This also takes care of assigning a collectionID
-  auto wrapper = new DataWrapper<podio::CollectionBase>();
-  wrapper->setData(e4hColl.release());
   auto sc = m_eventDataSvc->registerObject("/Event", "/" + std::string(name), wrapper);
   if (sc == StatusCode::FAILURE) {
     error() << "Could not register collection " << name << endmsg;

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -158,7 +158,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   for (const auto& [lcioName, edm4hepName] : collsToConvert) {
     try {
       auto* lcio_coll = the_event->getCollection(lcioName);
-      debug() << "Converting collection " << lcioName << " (storing it as " << edm4hepName << "). ";
+      debug() << "Converting collection " << lcioName << " (storing it as " << edm4hepName << "). " << endmsg;
       if (collectionExist(edm4hepName)) {
         debug() << "Collection already exists, skipping." << endmsg;
         continue; // No need to convert again

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -126,21 +126,25 @@ struct ObjectMappings {
 } // namespace
 
 StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
+  debug() << "Converting from EDM4hep to LCIO" << endmsg;
   auto& event = getEDM4hepEvent(this);
   LCIO2EDM4hepConv::convertObjectParameters(the_event, event);
 
   // Convert Event Header outside the collections loop
   if (!collectionExist(edm4hep::labels::EventHeader)) {
+    debug() << "Converting the EventHeader" << endmsg;
     registerCollection(edm4hep::labels::EventHeader, LCIO2EDM4hepConv::createEventHeader(the_event));
   }
 
   // Start off with the pre-defined collection name mappings
   auto collsToConvert{m_collNames.value()};
   if (m_convertAll) {
+    info() << "Converting all collections from LCIO to EDM4hep" << endmsg;
     const auto* collections = the_event->getCollectionNames();
     for (const auto& collName : *collections) {
       // And simply add the rest, exploiting the fact that emplace will not
       // replace existing entries with the same key
+      debug() << "Adding '" << collName << "' to be converted from the LCIO Event" << endmsg;
       collsToConvert.emplace(collName, collName);
     }
   }

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -83,6 +83,9 @@ void Lcio2EDM4hepTool::registerCollection(
   auto wrapper = new AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>(std::move(e4hColl));
   // No need to check for pre-existing collections, since we only ever end up
   // here if that is not the case
+  // NOTE: This also takes care of assigning a collectionID
+  auto wrapper = new DataWrapper<podio::CollectionBase>();
+  wrapper->setData(e4hColl.release());
   auto sc = m_eventDataSvc->registerObject("/Event", "/" + std::string(name), wrapper);
   if (sc == StatusCode::FAILURE) {
     error() << "Could not register collection " << name << endmsg;

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -28,6 +28,9 @@
 
 #include "k4FWCore/FunctionalUtils.h"
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -59,6 +62,7 @@ std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool* thisCla
     throw std::runtime_error("Failed to retrieve object leaves");
   }
   for (const auto& pReg : leaves) {
+    thisClass->verbose() << fmt::format("Now processing {} while obtaining collections", pReg->name()) << endmsg;
     if (pReg->name() == k4FWCore::frameLocation) {
       if (!returnFrameCollections)
         continue;
@@ -69,6 +73,9 @@ std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool* thisCla
       for (const auto& name : wrapper->getData().getAvailableCollections()) {
         collectionNames.push_back(name);
       }
+      thisClass->verbose() << fmt::format("Retrieved the following collection names from Frame in TES: {}",
+                                          collectionNames)
+                           << endmsg;
     }
     DataObject* p;
     sc = thisClass->evtSvc()->retrieveObject("/Event" + pReg->name(), p);
@@ -89,11 +96,18 @@ std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool* thisCla
     }
     // Remove the leading /
     auto name = pReg->name().substr(1, pReg->name().size() - 1);
+    thisClass->verbose() << "Adding '" << name << "' as collection name obtained from TES" << endmsg;
     collectionNames.push_back(name);
     if (idToName) {
       if (functionalWrapper) {
+        thisClass->verbose() << fmt::format("Retrieving id for '{}': {:0>8x}", name,
+                                            functionalWrapper->getData()->getID())
+                             << endmsg;
         idToName->emplace(functionalWrapper->getData()->getID(), std::move(name));
       } else {
+        thisClass->verbose() << fmt::format("Retrieving id for '{}': {:0>8x}", name,
+                                            algorithmWrapper->collectionBase()->getID())
+                             << endmsg;
         idToName->emplace(algorithmWrapper->collectionBase()->getID(), std::move(name));
       }
     }

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -103,12 +103,12 @@ std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool* thisCla
         thisClass->verbose() << fmt::format("Retrieving id for '{}': {:0>8x}", name,
                                             functionalWrapper->getData()->getID())
                              << endmsg;
-        idToName->emplace(functionalWrapper->getData()->getID(), std::move(name));
+        idToName->emplace(functionalWrapper->getData()->getID(), name);
       } else {
         thisClass->verbose() << fmt::format("Retrieving id for '{}': {:0>8x}", name,
                                             algorithmWrapper->collectionBase()->getID())
                              << endmsg;
-        idToName->emplace(algorithmWrapper->collectionBase()->getID(), std::move(name));
+        idToName->emplace(algorithmWrapper->collectionBase()->getID(), name);
       }
     }
   }

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -88,13 +88,13 @@ std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool* thisCla
       }
     }
     // Remove the leading /
-    const auto collName = pReg->name().substr(1, pReg->name().size() - 1);
-    collectionNames.push_back(collName);
+    auto name = pReg->name().substr(1, pReg->name().size() - 1);
+    collectionNames.push_back(name);
     if (idToName) {
       if (functionalWrapper) {
-        idToName->emplace(functionalWrapper->getData()->getID(), collName);
+        idToName->emplace(functionalWrapper->getData()->getID(), std::move(name));
       } else {
-        idToName->emplace(algorithmWrapper->collectionBase()->getID(), collName);
+        idToName->emplace(algorithmWrapper->collectionBase()->getID(), std::move(name));
       }
     }
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to properly clean up collection names when they are extracted from the Gaudi TES

ENDRELEASENOTES

Fixes #235 

- [ ] Tests
- [ ] Needs key4hep/k4FWCore#312
- [x] Needs #237 
- [x] Includes #239
- [x] Includes #238 
- [x] Includes #243 

@Zehvogel can you give this a go to see if it doesn't break other things?