### PR TITLE
Make sure to not double convert link collections

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -429,14 +429,14 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
   std::vector<std::tuple<std::string, const podio::CollectionBase*>> linkCollections{};
 
   for (const auto& [edm4hepName, lcioName] : m_collsToConvert) {
-    const auto coll = getEDM4hepCollection(edm4hepName);
-    if (coll->getTypeName().find("LinkCollection") != std::string_view::npos) {
-      debug() << edm4hepName << " is a link collection, converting it later" << endmsg;
-      linkCollections.emplace_back(lcioName, coll);
-      continue;
-    }
     debug() << "Converting collection " << edm4hepName << " (storing it as " << lcioName << ")" << endmsg;
     if (!EDM4hep2LCIOConv::collectionExist(lcioName, lcio_event)) {
+      const auto coll = getEDM4hepCollection(edm4hepName);
+      if (coll->getTypeName().find("LinkCollection") != std::string_view::npos) {
+        debug() << edm4hepName << " is a link collection, converting it later" << endmsg;
+        linkCollections.emplace_back(lcioName, coll);
+        continue;
+      }
       convertAdd(edm4hepName, lcioName, lcio_event, collection_pairs, pidCollections, dQdxCollections);
     } else {
       debug() << " Collection " << lcioName << " already in place, skipping conversion. " << endmsg;

--- a/test/gaudi_opts/test_link_conversion_edm4hep.py
+++ b/test/gaudi_opts/test_link_conversion_edm4hep.py
@@ -99,7 +99,30 @@ mcLinkConverter.collNameMapping = {
 mcLinkConverter.OutputLevel = DEBUG
 MarlinMCLinkChecker.EDM4hep2LcioTool = mcLinkConverter
 
-algList = [PseudoRecoAlg, MCRecoLinker, MarlinMCLinkChecker]
+# Another link checker and converter
+# We use this to avoid regressions for the fix in #237
+AnotherLinkChecker = MarlinProcessorWrapper(
+    "AnotherLinkChecker",
+    ProcessorType="MarlinMCRecoLinkChecker",
+    Parameters={
+        "MCRecoLinks": ["TrivialMCRecoLinks"],
+        "InputMCs": ["MCParticles"],
+        "InputRecos": ["PseudoRecoParticles"],
+    },
+)
+
+anotherLinkConverter = EDM4hep2LcioTool("AnotherLinkConverter")
+anotherLinkConverter.convertAll = True
+anotherLinkConverter.collNameMapping = {
+    "TrivialMCRecoLinks": "TrivialMCRecoLinks",
+    "MCParticles": "MCParticles",
+    "PseudoRecoParticles": "PseudoRecoParticles",
+}
+anotherLinkConverter.OutputLevel = DEBUG
+AnotherLinkChecker.EDM4hep2LcioTool = anotherLinkConverter
+
+
+algList = [PseudoRecoAlg, MCRecoLinker, MarlinMCLinkChecker, AnotherLinkChecker]
 
 if args.no_iosvc:
     algList = [podioInput] + algList


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that Link collections are properly skipped from conversion if they already exist in the LCIO event

ENDRELEASENOTES

- [x] Test case covering this
