### PR TITLE
Refactor retrieval of EDM4hep event Frame into method

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -121,7 +121,7 @@ private:
                   std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
                   std::vector<EDM4hep2LCIOConv::TrackDqdxConvData>& dQdxCollections);
 
-  std::optional<std::reference_wrapper<const podio::Frame>> getEDM4hepEvent() const;
+  const podio::Frame& getEDM4hepEvent() const;
 
   /// Get an EDM4hep collection by name, consulting either the podio based data
   /// svc or the IOSvc

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/EDM4hep2Lcio.h
@@ -121,6 +121,8 @@ private:
                   std::vector<EDM4hep2LCIOConv::ParticleIDConvData>& pidCollections,
                   std::vector<EDM4hep2LCIOConv::TrackDqdxConvData>& dQdxCollections);
 
+  std::optional<std::reference_wrapper<const podio::Frame>> getEDM4hepEvent() const;
+
   /// Get an EDM4hep collection by name, consulting either the podio based data
   /// svc or the IOSvc
   podio::CollectionBase* getEDM4hepCollection(const std::string& name) const;


### PR DESCRIPTION
BEGINRELEASENOTES
- Refactor the retrieval of the EDM4hep event (Frame) into standalone method

ENDRELEASENOTES

Another standalone outcome of #236 

As far as I can tell there is no way that the optional is not engaged that didn't already break before. The behavior before was
- If there is a PodioDataSvc, we get the event Frame from there
- Otherwise we get the Frame from where the IOSvc puts it
  - In case it is not there we create an empty local Frame

@jmcarcell anything I missed here about the previous behavior?