### PR TITLE
Move duplicated code into helper function

### DIFF
--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -58,7 +58,9 @@ target_include_directories(MarlinWrapper PUBLIC
 gaudi_add_library(k4MarlinWrapperUtils SHARED
   SOURCES
     src/components/StoreUtils.cpp
-  LINK k4FWCore::k4FWCore
+  LINK
+    k4FWCore::k4FWCore
+    k4EDM4hep2LcioConv::k4EDM4hep2LcioConv
 )
 
 # EDM4hep2lcio

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 #include "k4MarlinWrapper/converters/EDM4hep2Lcio.h"
-#include "GlobalConvertedObjectsMap.h"
 #include "StoreUtils.h"
 #include <GaudiKernel/StatusCode.h>
 
@@ -483,22 +482,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
 
   EDM4hep2LCIOConv::attachDqdxInfo(collection_pairs.tracks, dQdxCollections);
 
-  // We want one "global" map that is created the first time it is used in the event.
-  DataObject* obj = nullptr;
-  auto sc = evtSvc()->retrieveObject(GlobalConvertedObjectsMap::TESpath.data(), obj);
-  if (sc.isFailure()) {
-    debug() << "Creating GlobalconvertedObjectsMap for this event since it is not already in the EventStore" << endmsg;
-    auto globalObjMapWrapper = new AnyDataWrapper(GlobalConvertedObjectsMap{});
-    auto nsc = evtSvc()->registerObject(GlobalConvertedObjectsMap::TESpath.data(), globalObjMapWrapper);
-    if (nsc.isFailure()) {
-      error() << "Could not register GlobalConvertedObjectsMap in the EventStore" << endmsg;
-      return StatusCode::FAILURE;
-    }
-    obj = globalObjMapWrapper;
-  }
-
-  auto globalObjMapWrapper = static_cast<AnyDataWrapper<GlobalConvertedObjectsMap>*>(obj);
-  auto& globalObjMap = globalObjMapWrapper->getData();
+  auto& globalObjMap = getGlobalObjectMap(this);
 
   debug() << "Updating global object map" << endmsg;
   globalObjMap.update(collection_pairs);

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -249,22 +249,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
     }
   }
 
-  // We want one "global" map that is created the first time it is used in the event.
-  DataObject* obj = nullptr;
-  auto sc = evtSvc()->retrieveObject(GlobalConvertedObjectsMap::TESpath.data(), obj);
-  if (sc.isFailure()) {
-    debug() << "Creating GlobalconvertedObjectsMap for this event since it is not already in the EventStore" << endmsg;
-    auto globalObjMapWrapper = new AnyDataWrapper(GlobalConvertedObjectsMap{});
-    auto nsc = evtSvc()->registerObject(GlobalConvertedObjectsMap::TESpath.data(), globalObjMapWrapper);
-    if (nsc.isFailure()) {
-      error() << "Could not register GlobalConvertedObjectsMap in the EventStore" << endmsg;
-      return StatusCode::FAILURE;
-    }
-    obj = globalObjMapWrapper;
-  }
-
-  auto globalObjMapWrapper = static_cast<AnyDataWrapper<GlobalConvertedObjectsMap>*>(obj);
-  auto& globalObjMap = globalObjMapWrapper->getData();
+  auto& globalObjMap = getGlobalObjectMap(this);
 
   globalObjMap.update(lcio2edm4hepMaps);
 

--- a/k4MarlinWrapper/src/components/StoreUtils.cpp
+++ b/k4MarlinWrapper/src/components/StoreUtils.cpp
@@ -99,3 +99,24 @@ std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool* thisCla
   }
   return collectionNames;
 }
+
+k4MarlinWrapper::GlobalConvertedObjectsMap& getGlobalObjectMap(AlgTool* thisTool) {
+  // We want one "global" map that is created the first time it is used in the event.
+  DataObject* obj = nullptr;
+  auto sc = thisTool->evtSvc()->retrieveObject(k4MarlinWrapper::GlobalConvertedObjectsMap::TESpath.data(), obj);
+  if (sc.isFailure()) {
+    thisTool->debug() << "Creating GlobalconvertedObjectsMap for this event since it is not already in the EventStore"
+                      << endmsg;
+    auto globalObjMapWrapper = new AnyDataWrapper(k4MarlinWrapper::GlobalConvertedObjectsMap{});
+    auto nsc = thisTool->evtSvc()->registerObject(k4MarlinWrapper::GlobalConvertedObjectsMap::TESpath.data(),
+                                                  globalObjMapWrapper);
+    if (nsc.isFailure()) {
+      thisTool->error() << "Could not register GlobalConvertedObjectsMap in the EventStore" << endmsg;
+      throw std::runtime_error("Could not register GlobalConvertedObjectsMap in the EventStore");
+    }
+    obj = globalObjMapWrapper;
+  }
+
+  auto globalObjMapWrapper = static_cast<AnyDataWrapper<k4MarlinWrapper::GlobalConvertedObjectsMap>*>(obj);
+  return globalObjMapWrapper->getData();
+}

--- a/k4MarlinWrapper/src/components/StoreUtils.h
+++ b/k4MarlinWrapper/src/components/StoreUtils.h
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "GlobalConvertedObjectsMap.h"
+
 #include "GaudiKernel/AlgTool.h"
 
 #include <string>
@@ -27,3 +29,5 @@
 std::vector<std::string> getAvailableCollectionsFromStore(const AlgTool* thisClass,
                                                           std::optional<std::map<uint32_t, std::string>>& idToName,
                                                           bool returnFrameCollections = false);
+
+k4MarlinWrapper::GlobalConvertedObjectsMap& getGlobalObjectMap(AlgTool* thisTool);


### PR DESCRIPTION
BEGINRELEASENOTES
- Refactor duplicated code to retrieve the global converted objects map into a helper function and call that instead

ENDRELEASENOTES

Another off-spring of #236 