### PR TITLE
Run pre-commit on Ubuntu 24 runners

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3.1


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to an Ubuntu 24 runner to run pre-commit

ENDRELEASENOTES
