### PR TITLE
Move DataHandle and MetaDataHandle to the k4FWCore namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(Gaudi REQUIRED)
 find_package(LCIO REQUIRED)
 find_package(Marlin REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
-find_package(k4FWCore 1.2.0 REQUIRED)
+find_package(k4FWCore 1.3.0 REQUIRED)
 find_package(k4EDM4hep2LcioConv 0.11 REQUIRED)
 
 include(CTest)

--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -90,7 +90,7 @@ StatusCode EDM4hep2LcioTool::finalize() { return AlgTool::finalize(); }
 // Add LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertTracks(TrackMap& tracks_vec, const std::string& e4h_coll_name,
                                      const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::TrackCollection> tracks_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::TrackCollection> tracks_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto* tracks_coll = tracks_handle.get();
 
   auto conv_tracks = EDM4hep2LCIOConv::convertTracks(tracks_coll, tracks_vec);
@@ -104,10 +104,10 @@ void EDM4hep2LcioTool::convertTracks(TrackMap& tracks_vec, const std::string& e4
 // Add LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertTrackerHits(TrackerHitMap& trackerhits_vec, const std::string& e4h_coll_name,
                                           const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::TrackerHit3DCollection> trackerhits_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> trackerhits_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto trackerhits_coll = trackerhits_handle.get();
 
-  MetaDataHandle<std::string> cellIDStrHandle{trackerhits_handle, edm4hep::labels::CellIDEncoding,
+  k4FWCore::MetaDataHandle<std::string> cellIDStrHandle{trackerhits_handle, edm4hep::labels::CellIDEncoding,
                                               Gaudi::DataHandle::Reader};
 
   auto conv_trackerhits =
@@ -118,17 +118,17 @@ void EDM4hep2LcioTool::convertTrackerHits(TrackerHitMap& trackerhits_vec, const 
 }
 
 void EDM4hep2LcioTool::convertParticleIDs(ParticleIDMap& pidMap, const std::string& e4h_coll_name, int32_t algoId) {
-  DataHandle<edm4hep::ParticleIDCollection> pidHandle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::ParticleIDCollection> pidHandle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
 
   EDM4hep2LCIOConv::convertParticleIDs(pidHandle.get(), pidMap, algoId);
 }
 
 void EDM4hep2LcioTool::convertTrackerHitPlanes(TrackerHitPlaneMap& trackerhits_vec, const std::string& e4h_coll_name,
                                                const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::TrackerHitPlaneCollection> trackerhits_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::TrackerHitPlaneCollection> trackerhits_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto trackerhits_coll = trackerhits_handle.get();
 
-  MetaDataHandle<std::string> cellIDStrHandle{trackerhits_handle, edm4hep::labels::CellIDEncoding,
+  k4FWCore::MetaDataHandle<std::string> cellIDStrHandle{trackerhits_handle, edm4hep::labels::CellIDEncoding,
                                               Gaudi::DataHandle::Reader};
 
   auto conv_trackerhits =
@@ -143,10 +143,10 @@ void EDM4hep2LcioTool::convertTrackerHitPlanes(TrackerHitPlaneMap& trackerhits_v
 // Add LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertSimTrackerHits(SimTrackerHitMap& simtrackerhits_vec, const std::string& e4h_coll_name,
                                              const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::SimTrackerHitCollection> simtrackerhits_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> simtrackerhits_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto simtrackerhits_coll = simtrackerhits_handle.get();
 
-  MetaDataHandle<std::string> cellIDHandle{simtrackerhits_handle, edm4hep::labels::CellIDEncoding,
+  k4FWCore::MetaDataHandle<std::string> cellIDHandle{simtrackerhits_handle, edm4hep::labels::CellIDEncoding,
                                            Gaudi::DataHandle::Reader};
   const auto cellIDstr = cellIDHandle.get();
 
@@ -162,10 +162,10 @@ void EDM4hep2LcioTool::convertSimTrackerHits(SimTrackerHitMap& simtrackerhits_ve
 // Add converted LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertCalorimeterHits(CaloHitMap& calo_hits_vec, const std::string& e4h_coll_name,
                                               const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::CalorimeterHitCollection> calohit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> calohit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto calohit_coll = calohit_handle.get();
 
-  MetaDataHandle<std::string> cellIDHandle{calohit_handle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
+  k4FWCore::MetaDataHandle<std::string> cellIDHandle{calohit_handle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
   const auto cellIDstr = cellIDHandle.get();
 
   auto conv_calohits = EDM4hep2LCIOConv::convertCalorimeterHits(calohit_coll, cellIDstr, calo_hits_vec);
@@ -179,7 +179,7 @@ void EDM4hep2LcioTool::convertCalorimeterHits(CaloHitMap& calo_hits_vec, const s
 // Add converted LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertRawCalorimeterHits(RawCaloHitMap& raw_calo_hits_vec, const std::string& e4h_coll_name,
                                                  const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::RawCalorimeterHitCollection> raw_calohit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::RawCalorimeterHitCollection> raw_calohit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto rawcalohit_coll = raw_calohit_handle.get();
 
   auto conv_rawcalohits = EDM4hep2LCIOConv::convertRawCalorimeterHits(rawcalohit_coll, raw_calo_hits_vec);
@@ -193,10 +193,10 @@ void EDM4hep2LcioTool::convertRawCalorimeterHits(RawCaloHitMap& raw_calo_hits_ve
 // Add converted LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertSimCalorimeterHits(SimCaloHitMap& sim_calo_hits_vec, const std::string& e4h_coll_name,
                                                  const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::SimCalorimeterHitCollection> sim_calohit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> sim_calohit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto simcalohit_coll = sim_calohit_handle.get();
 
-  MetaDataHandle<std::string> cellIDHandle{sim_calohit_handle, edm4hep::labels::CellIDEncoding,
+  k4FWCore::MetaDataHandle<std::string> cellIDHandle{sim_calohit_handle, edm4hep::labels::CellIDEncoding,
                                            Gaudi::DataHandle::Reader};
   const auto cellIDstr = cellIDHandle.get();
 
@@ -212,7 +212,7 @@ void EDM4hep2LcioTool::convertSimCalorimeterHits(SimCaloHitMap& sim_calo_hits_ve
 // Add converted LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertTPCHits(TPCHitMap& tpc_hits_vec, const std::string& e4h_coll_name,
                                       const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::RawTimeSeriesCollection> tpchit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::RawTimeSeriesCollection> tpchit_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto tpchit_coll = tpchit_handle.get();
 
   auto conv_tpchits = EDM4hep2LCIOConv::convertTPCHits(tpchit_coll, tpc_hits_vec);
@@ -226,7 +226,7 @@ void EDM4hep2LcioTool::convertTPCHits(TPCHitMap& tpc_hits_vec, const std::string
 // Add converted LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertClusters(ClusterMap& cluster_vec, const std::string& e4h_coll_name,
                                        const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::ClusterCollection> cluster_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::ClusterCollection> cluster_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto cluster_coll = cluster_handle.get();
 
   auto conv_clusters = EDM4hep2LCIOConv::convertClusters(cluster_coll, cluster_vec);
@@ -240,7 +240,7 @@ void EDM4hep2LcioTool::convertClusters(ClusterMap& cluster_vec, const std::strin
 // Add converted LCIO Collection Vector to LCIO event
 void EDM4hep2LcioTool::convertVertices(VertexMap& vertex_vec, const std::string& e4h_coll_name,
                                        const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::VertexCollection> vertex_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::VertexCollection> vertex_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto vertex_coll = vertex_handle.get();
 
   auto conv_vertices = EDM4hep2LCIOConv::convertVertices(vertex_coll, vertex_vec);
@@ -255,7 +255,7 @@ void EDM4hep2LcioTool::convertVertices(VertexMap& vertex_vec, const std::string&
 void EDM4hep2LcioTool::convertMCParticles(MCParticleMap& mc_particles_vec, const std::string& e4h_coll_name,
                                           const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
   // MCParticles handle
-  DataHandle<edm4hep::MCParticleCollection> mcparticle_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::MCParticleCollection> mcparticle_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto mcparticle_coll = mcparticle_handle.get();
 
   auto conv_mcparticles = EDM4hep2LCIOConv::convertMCParticles(mcparticle_coll, mc_particles_vec);
@@ -271,7 +271,7 @@ void EDM4hep2LcioTool::convertReconstructedParticles(RecoParticleMap& recopartic
                                                      const std::string& e4h_coll_name,
                                                      const std::string& lcio_coll_name, lcio::LCEventImpl* lcio_event) {
   // ReconstructedParticles handle
-  DataHandle<edm4hep::ReconstructedParticleCollection> recos_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::ReconstructedParticleCollection> recos_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto recos_coll = recos_handle.get();
 
   auto conv_recops = EDM4hep2LCIOConv::convertReconstructedParticles(recos_coll, recoparticles_vec);
@@ -282,7 +282,7 @@ void EDM4hep2LcioTool::convertReconstructedParticles(RecoParticleMap& recopartic
 
 // Transfer info from EDM4hep EventHeader to LCIO event
 void EDM4hep2LcioTool::convertEventHeader(const std::string& e4h_coll_name, lcio::LCEventImpl* lcio_event) {
-  DataHandle<edm4hep::EventHeaderCollection> header_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
+  k4FWCore::DataHandle<edm4hep::EventHeaderCollection> header_handle{e4h_coll_name, Gaudi::DataHandle::Reader, this};
   const auto header_coll = header_handle.get();
 
   if (header_coll->size() != 1) {

--- a/test/src/MCRecoLinkChecker.h
+++ b/test/src/MCRecoLinkChecker.h
@@ -36,10 +36,10 @@ public:
   StatusCode execute(const EventContext&) const;
 
 private:
-  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_relationCollHandle{"MCRecoTruthLinks",
+  mutable k4FWCore::DataHandle<edm4hep::RecoMCParticleLinkCollection> m_relationCollHandle{"MCRecoTruthLinks",
                                                                                  Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcCollHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_recoCollHandle{"RecoParticles",
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcCollHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ReconstructedParticleCollection> m_recoCollHandle{"RecoParticles",
                                                                                 Gaudi::DataHandle::Reader, this};
 };
 

--- a/test/src/PseudoRecoAlgorithm.h
+++ b/test/src/PseudoRecoAlgorithm.h
@@ -32,7 +32,7 @@ public:
   StatusCode execute(const EventContext&) const override;
 
 private:
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcCollHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_recoCollHandle{"RecoParticles",
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcCollHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ReconstructedParticleCollection> m_recoCollHandle{"RecoParticles",
                                                                                 Gaudi::DataHandle::Writer, this};
 };


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DataHandle and MetaDataHandle to the k4FWCore namespace, done in k4FWCore in https://github.com/key4hep/k4FWCore/pull/317
- Bump the required version of k4FWCore

ENDRELEASENOTES