### PR TITLE
Add missing newlines for debug output

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -411,7 +411,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
         edmEvent = m_podioDataSvc->getEventFrame();
         for (const auto& name : edmEvent.value().get().getAvailableCollections()) {
           const auto& [_, inserted] = collNameMapping.emplace(name, name);
-          debug() << fmt::format("Adding '{}' from Frame to conversion? {}", name, inserted);
+          debug() << fmt::format("Adding '{}' from Frame to conversion? {}", name, inserted) << endmsg;
         }
       }
       // Always check the contents of the TES because algorithms that do not use
@@ -420,7 +420,7 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
       std::optional<std::map<uint32_t, std::string>> idToNameOpt(std::move(m_idToName));
       for (const auto& name : getAvailableCollectionsFromStore(this, idToNameOpt)) {
         const auto& [_, inserted] = collNameMapping.emplace(name, name);
-        debug() << fmt::format("Adding '{}' from TES to conversion? {}", name, inserted);
+        debug() << fmt::format("Adding '{}' from TES to conversion? {}", name, inserted) << endmsg;
       }
       m_idToName = std::move(idToNameOpt.value());
 


### PR DESCRIPTION
BEGINRELEASENOTES
- EDM4hep2LCIO: Add missing newlines to debug outputs to improve readability

ENDRELEASENOTES

Lifted from #236 
