### PR TITLE
Remove a useless gaudi_install call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,5 +46,3 @@ add_subdirectory(k4MarlinWrapper)
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
-
-gaudi_install(CMAKE)


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove a useless gaudi_install call 

ENDRELEASENOTES

This is not doing anything, how it's used is `gaudi_install(CMAKE cmake/<project>Config.cmake` for example.