### PR TITLE
Make it possible again to not convert everything

### DIFF
--- a/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
+++ b/k4MarlinWrapper/src/components/EDM4hep2Lcio.cpp
@@ -456,10 +456,9 @@ StatusCode EDM4hep2LcioTool::convertCollections(lcio::LCEventImpl* lcio_event) {
         debug() << fmt::format("Adding '{}' from TES to conversion? {}", name, inserted) << endmsg;
       }
       m_idToName = std::move(idToNameOpt.value());
-
-      for (auto&& [origName, newName] : collNameMapping) {
-        m_collsToConvert.emplace_back(std::move(origName), std::move(newName));
-      }
+    }
+    for (auto&& [origName, newName] : collNameMapping) {
+      m_collsToConvert.emplace_back(std::move(origName), std::move(newName));
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,6 +176,11 @@ ExternalData_Add_Test( marlinwrapper_tests
   COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_io_utilities.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root} --with-gaudi-algorithm --output-type both --outputbase edm4hep_both_out_marlin_gaudi
 )
 
+ExternalData_Add_Test( marlinwrapper_tests
+  NAME partial_edm4hep_to_lcio
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_partial_conversion.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
+)
+
 add_test( event_header_conversion bash -c "k4run ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/createEventHeader.py && anajob test.slcio | grep 'EVENT: 42'" )
 
 ExternalData_Add_Target(marlinwrapper_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -181,6 +181,16 @@ ExternalData_Add_Test( marlinwrapper_tests
   COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_partial_conversion.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )
 
+add_test(check_lcio_output_partial_conversion
+  bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_lcio_output_partial_conversion.sh partially_converted_lcio_output.slcio"
+)
+
+set_tests_properties(
+  check_lcio_output_partial_conversion
+  PROPERTIES
+  DEPENDS partial_edm4hep_to_lcio
+)
+
 add_test( event_header_conversion bash -c "k4run ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/createEventHeader.py && anajob test.slcio | grep 'EVENT: 42'" )
 
 ExternalData_Add_Target(marlinwrapper_tests)

--- a/test/gaudi_opts/test_partial_conversion.py
+++ b/test/gaudi_opts/test_partial_conversion.py
@@ -50,6 +50,13 @@ wrapped_alg = MarlinProcessorWrapper(
 )
 algList.append(wrapped_alg)
 
+lcio_writer = io_handler.add_lcio_writer("LCIOWriter")
+lcio_writer.Parameters = {
+    "CompressionLevel": ["6"],
+    "LCIOOutputFile": ["partially_converted_lcio_output.slcio"],
+    "LCIOWriteMode": ["WRITE_NEW"],
+}
+
 input_conv = EDM4hep2LcioTool("InputConversion")
 input_conv.convertAll = False
 input_conv.collNameMapping = {"MCParticles": "MCParticle"}

--- a/test/gaudi_opts/test_partial_conversion.py
+++ b/test/gaudi_opts/test_partial_conversion.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2019-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from Gaudi.Configurables import (
+    MarlinProcessorWrapper,
+    EventDataSvc,
+    EDM4hep2LcioTool,
+)
+from Gaudi.Configuration import DEBUG
+
+from k4FWCore import ApplicationMgr, IOSvc
+from k4FWCore.parseArgs import parser
+
+from k4MarlinWrapper.io_helpers import IOHandlerHelper
+
+parser.add_argument("--inputfile", help="The name of the input file")
+
+args = parser.parse_known_args()[0]
+
+algList = []
+evtsvc = EventDataSvc("EventDataSvc")
+iosvc = IOSvc()
+
+io_handler = IOHandlerHelper(algList, iosvc)
+
+io_handler.add_reader([args.inputfile])
+
+wrapped_alg = MarlinProcessorWrapper(
+    "PseudoReco",
+    ProcessorType="PseudoRecoProcessor",
+    Parameters={"InputMCs": ["MCParticle"], "OutputRecos": ["PseudoRecoParticles"]},
+    OutputLevel=DEBUG,
+)
+algList.append(wrapped_alg)
+
+input_conv = EDM4hep2LcioTool("InputConversion")
+input_conv.convertAll = False
+input_conv.collNameMapping = {"MCParticles": "MCParticle"}
+wrapped_alg.EDM4hep2LcioTool = input_conv
+
+ApplicationMgr(TopAlg=algList, EvtSel="NONE", EvtMax=1, ExtSvc=[evtsvc], OutputLevel=DEBUG)

--- a/test/scripts/check_lcio_output_partial_conversion.sh
+++ b/test/scripts/check_lcio_output_partial_conversion.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+##
+## Copyright (c) 2019-2024 Key4hep-Project.
+##
+## This file is part of Key4hep.
+## See https://key4hep.github.io/key4hep-doc/ for further info.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+# This script confirms that the input file has only two LCIO collections which
+# are named MCParticle and PseudoRecoParticles respectively.
+
+set -e
+
+# The following command extracts the collection names from the table that is
+# printed by anajob using the first awk invocation. The rest is then simply
+# turning the list of collection names into a colon separated list which we can
+# then compare against our expectations
+collections=$(anajob ${1} | awk '/COLLECTION NAME/ {table=1; next} /^======/ {next} /^------/ {table=0} table' | awk '{print $1}' | tr '\n' ':')
+
+if [ ${collections} != "MCParticle:PseudoRecoParticles:" ]; then
+    echo "Expected collections MCParticle:PseudoRecoParticles: but got ${collections}"
+    exit 1
+fi


### PR DESCRIPTION
BEGINRELEASENOTES
-  Make it possible again to use the collection mapping to specify which collections should be converted

ENDRELEASENOTES

Looks like this accidentally disappeared in https://github.com/key4hep/k4MarlinWrapper/pull/233, due to counting braces on GitHub being very annoying :(

Discovered while trying to work around https://github.com/key4hep/k4EDM4hep2LcioConv/issues/122 by only converting what is needed. We should probably add a test for this :/

@tmadlener