### PR TITLE
Lower the amount of output messages in clicReconstruction_mt.py

### DIFF
--- a/test/gaudi_opts/clicReconstruction_mt.py
+++ b/test/gaudi_opts/clicReconstruction_mt.py
@@ -2272,7 +2272,7 @@ algList.append(MyLcioEventOutput_DST)
 ###########################################################
 for algo in algList:
     algo.Cardinality = cardinality
-    algo.OutputLevel = DEBUG
+    algo.OutputLevel = INFO
 
 seq = Sequencer("createViewSeq", Members=algList, Sequential=True, OutputLevel=VERBOSE)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Lower the amount of output messages in clicReconstruction_mt.py 

ENDRELEASENOTES

Because when it fails the logs are too big: see https://github.com/key4hep/k4MarlinWrapper/issues/247