### PR TITLE
Merge all Gaudi plugins into a single Plugins library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(cmake/Key4hepConfig.cmake)
 include(GNUInstallDirs)
 
 find_package(Gaudi REQUIRED)
-find_package(LCIO REQUIRED)
+find_package(LCIO 2.21 REQUIRED)
 find_package(Marlin REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
 find_package(k4FWCore 1.3.0 REQUIRED)

--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -25,33 +25,20 @@ gaudi_add_module(k4MarlinWrapperPlugins
   SOURCES
     src/components/LcioEventAlgo.cpp
     src/components/LcioEventOutput.cpp
+    src/components/MarlinProcessorWrapper.cpp
+    src/components/TrackingCellIDEncodingSvc.cpp
   LINK
     Gaudi::GaudiKernel
     ${Marlin_LIBRARIES}
+    k4FWCore::k4FWCore
+    k4FWCore::k4Interface
+    EDM4HEP::edm4hep
+    LCIO::lcio
 )
 
 target_include_directories(k4MarlinWrapperPlugins PUBLIC
   ${PROJECT_SOURCE_DIR}/k4MarlinWrapper
-  ${LCIO_INCLUDE_DIRS}
   ${Marlin_INCLUDE_DIRS}
-)
-
-# MarlinWrapper
-gaudi_add_module(MarlinWrapper
-  SOURCES
-    src/components/MarlinProcessorWrapper.cpp
-    src/components/TrackingCellIDEncodingSvc.cpp
-  LINK
-    k4FWCore::k4FWCore
-    k4FWCore::k4Interface
-    ${Marlin_LIBRARIES}
-    EDM4HEP::edm4hep
-)
-
-target_include_directories(MarlinWrapper PUBLIC
-  ${PROJECT_SOURCE_DIR}/k4MarlinWrapper
-  ${Marlin_INCLUDE_DIRS}
-  ${LCIO_INCLUDE_DIRS}
 )
 
 # k4MarlinWrapperUtils
@@ -100,7 +87,7 @@ target_include_directories(Lcio2EDM4hep PUBLIC
 
 # Copy python parsing file to genConfDir in Gaudi
 add_custom_command(
-        TARGET MarlinWrapper POST_BUILD
+        TARGET k4MarlinWrapperPlugins POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
                 ${PROJECT_SOURCE_DIR}/k4MarlinWrapper/python/k4MarlinWrapper/parseConstants.py
                 ${CMAKE_CURRENT_BINARY_DIR}/genConfDir/k4MarlinWrapper/parseConstants.py)

--- a/k4MarlinWrapper/CMakeLists.txt
+++ b/k4MarlinWrapper/CMakeLists.txt
@@ -57,7 +57,7 @@ gaudi_add_module(EDM4hep2Lcio
   LINK
     k4EDM4hep2LcioConv::k4EDM4hep2LcioConv
     k4FWCore::k4FWCore
-    ${LCIO_LIBRARIES}
+    LCIO::lcio
     ${Marlin_LIBRARIES}
     EDM4HEP::edm4hep
     k4MarlinWrapperUtils
@@ -65,7 +65,6 @@ gaudi_add_module(EDM4hep2Lcio
 
 target_include_directories(EDM4hep2Lcio PUBLIC
   ${PROJECT_SOURCE_DIR}/k4MarlinWrapper
-  ${LCIO_INCLUDE_DIRS}
   ${Marlin_INCLUDE_DIRS}
 )
 
@@ -78,11 +77,11 @@ gaudi_add_module(Lcio2EDM4hep
     k4FWCore::k4FWCore
     k4EDM4hep2LcioConv::k4EDM4hep2LcioConv
     k4MarlinWrapperUtils
+    LCIO::lcio
 )
 
 target_include_directories(Lcio2EDM4hep PUBLIC
   ${PROJECT_SOURCE_DIR}/k4MarlinWrapper
-  ${LCIO_INCLUDE_DIRS}
 )
 
 # Copy python parsing file to genConfDir in Gaudi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -177,6 +177,11 @@ ExternalData_Add_Test( marlinwrapper_tests
 )
 
 ExternalData_Add_Test( marlinwrapper_tests
+  NAME lcio_event_only
+  COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/lcio_event_only.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/muons.slcio}
+)
+
+ExternalData_Add_Test( marlinwrapper_tests
   NAME partial_edm4hep_to_lcio
   COMMAND ${K4RUN} ${CMAKE_CURRENT_SOURCE_DIR}/gaudi_opts/test_partial_conversion.py --inputfile DATA{${PROJECT_SOURCE_DIR}/test/input_files/ttbar_20240223_edm4hep.root}
 )

--- a/test/gaudi_opts/lcio_event_only.py
+++ b/test/gaudi_opts/lcio_event_only.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2019-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from Gaudi.Configuration import DEBUG
+from Configurables import EventDataSvc
+from k4FWCore import IOSvc, ApplicationMgr
+from k4FWCore.parseArgs import parser
+from k4MarlinWrapper.io_helpers import IOHandlerHelper
+
+parser.add_argument("--inputfile", help="The name of the input file")
+
+args = parser.parse_known_args()[0]
+
+io_svc = IOSvc()
+
+alg_list = []
+io_handler = IOHandlerHelper(alg_list, io_svc)
+io_handler.add_reader([args.inputfile])
+
+io_handler.finalize_converters()
+ApplicationMgr(
+    TopAlg=alg_list,
+    EvtSel="NONE",
+    EvtMax=3,
+    ExtSvc=[EventDataSvc()],
+    OutputLevel=DEBUG,
+)


### PR DESCRIPTION
BEGINRELEASENOTES
- Merge the `MarlinWrapper` into the `k4MarlinWrapperPlugins` library to ensure that necessary global Marlin related variables are intialized properly for all Gaudi components that we export from here.
- CMake: Switch to use LCIO cmake targets, requires LCIO 2.21.0

ENDRELEASENOTES

Fixes #250 

@andresailer @jmcarcell do you see anything that speaks against this merge (historical, technical)? I can build the local stack without issues with this.
