### PR TITLE
Do not refresh seeds for every instance

### DIFF
--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -261,7 +261,7 @@ StatusCode MarlinProcessorWrapper::execute(const EventContext&) const {
     scope.setLevel(m_verbosity);
 
     // Ensure modifyEvent is called exactly once per event by the first processor
-    static thread_local lcio::LCEvent* lastProcessedEvent = nullptr;
+    static IMPL::LCEventImpl* lastProcessedEvent = nullptr;
     if (lastProcessedEvent != the_event) {
       debug() << "Calling into marlin::ProcessorMgr to refresh random seeds  " << endmsg;
       auto* procMgr = marlin::ProcessorMgr::instance();


### PR DESCRIPTION
BEGINRELEASENOTES
- Refresh the seeds for Marlin exactly once instead of doing it for every wrapped processor (over and over)

ENDRELEASENOTES

@andresailer does this look like a viable solution to you? I am happy to take back the second commit otherwise.

- [x] Needs #255 
