### PR TITLE
Make sure to have a valid logscope for seed refreshing

### DIFF
--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -259,12 +259,12 @@ StatusCode MarlinProcessorWrapper::execute(const EventContext&) const {
   // once for each execute call
   // how can this be done more efficiently?
   try {
-    auto* procMgr = marlin::ProcessorMgr::instance();
-    procMgr->modifyEvent(the_event);
-
     streamlog::logscope scope(streamlog::out);
     scope.setName(name());
     scope.setLevel(m_verbosity);
+
+    auto* procMgr = marlin::ProcessorMgr::instance();
+    procMgr->modifyEvent(the_event);
 
     // process the event in the processor
     auto modifier = dynamic_cast<marlin::EventModifier*>(m_processor);


### PR DESCRIPTION
Otherwise debug message from Marlin will be emitted regardless of actual loglevel of the algorithm.


BEGINRELEASENOTES
- Make sure to set the logscope and corresponding log level before doing this to avoid emitting DEBUG output from Marlin independent of the output level of the algorithm

ENDRELEASENOTES

Pulled out of #254 
