### PR TITLE
upstream `parse_collection_patch_file` helper

### DIFF
--- a/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
+++ b/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
@@ -199,6 +199,7 @@ class IOHandlerHelper:
                     )
                     break
 
+
 def parse_collection_patch_file(patch_file: Union[str, os.PathLike]) -> List[str]:
     """Parse a collection patch file such that it can be used by the
     PatchCollections processor.


### PR DESCRIPTION
BEGINRELEASENOTES
- Upstream the `parse_collection_patch_file` helper [from ILDConfig](https://github.com/iLCSoft/ILDConfig/blob/master/StandardConfig/production/py_utils.py), it is used by both CLD and ILD.

ENDRELEASENOTES

