### PR TITLE
Fix test after the logging default changed in https://github.com/key4hep/k4FWCore/pull/361

### DIFF
--- a/test/gaudi_opts/createEventHeader.py
+++ b/test/gaudi_opts/createEventHeader.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from Gaudi.Configuration import WARNING
+from Gaudi.Configuration import INFO
 
 from Configurables import (
     EventHeaderCreator,
@@ -61,5 +61,5 @@ ApplicationMgr(
     EvtSel="NONE",
     EvtMax=2,
     ExtSvc=[EventDataSvc()],
-    OutputLevel=WARNING,
+    OutputLevel=INFO,
 )


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix test after the logging default changed in https://github.com/key4hep/k4FWCore/pull/361

ENDRELEASENOTES

Previously, it was always being set to `INFO` by default, and the `WARNING` here
prevented the message that is needed by the test to be printed. Example of the error:

```
35/36 Test #36: event_header_conversion_no_header .......................***Failed  Required regular expression not found. Regex=[INFO The EventHeader collection is not available. Not converting it.
]  1.48 sec
[k4run - INFO] k4run.main: --> out
[k4run - INFO] k4run.main: Option name: MetadataSvc.OutputLevel 0
[k4run - INFO] k4run.main: Option name: out.OutputLevel 0
[k4run - INFO] k4run.main: Option name: out.Asynchronous False
[k4run - INFO] k4run.main: Option name: out.ProcessorType LCIOOutputProcessor
[k4run - INFO] k4run.main: Option name: out.Parameters {'LCIOOutputFile': ['test_without_header.slcio'], 'LCIOWriteMode': ['WRITE_NEW']}
[k4run - INFO] k4run.main: Option name: EventDataSvc.OutputLevel 0
[k4run - INFO] k4run.main: Option name: eventHeaderCreator.OutputLevel 0
[k4run - INFO] k4run.main: Option name: eventHeaderCreator.Asynchronous False
[k4run - INFO] k4run.main: Option name: eventHeaderCreator.runNumber 1
[k4run - INFO] k4run.main: Option name: eventHeaderCreator.eventNumberOffset 42
[k4run - INFO] k4run.main: Option name: IOSvc.OutputLevel 0
[k4run - INFO] k4run.main: Option name: IOSvc.CollectionNames []
[k4run - INFO] k4run.main: Option name: IOSvc.Input []
[k4run - INFO] k4run.main: Option name: IOSvc.Output 
[k4run - INFO] k4run.main: Option name: IOSvc.outputCommands ['keep *']
[k4run - INFO] k4run.main: Option name: IOSvc.OutputType default
[k4run - INFO] k4run.main: Option name: IOSvc.ImportedFromk4FWCore True
[k4run - INFO] k4run.main: Option name: IOSvc.FirstEventEntry 0
ApplicationMgr    SUCCESS 
====================================================================================================================================
                                                   Welcome to ApplicationMgr (GaudiCoreSvc v40r0)
                                          running on 4de6768babd1 on Tue Nov 25 05:27:30 2025
====================================================================================================================================
PersistencyIO    INFO  +++ Set Streamer to dd4hep::OpaqueDataBlock
```