### PR TITLE
Set the CellID encoding parameters at `finalize` in `Lcio2EDM4hep.cpp`

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -64,6 +64,8 @@ private:
   SmartIF<IMetadataSvc> m_metadataSvc;
   PodioDataSvc* m_podioDataSvc;
 
+  std::map<std::string, std::string> m_cellIDEncodings{};
+
   // **********************************
   // Check if a collection was already registered to skip it
   // **********************************

--- a/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/converters/Lcio2EDM4hep.h
@@ -26,6 +26,8 @@
 
 #include "k4MarlinWrapper/converters/IEDMConverter.h"
 
+#include <edm4hep/utils/ParticleIDUtils.h>
+
 #include <lcio.h>
 
 #include <map>
@@ -65,6 +67,7 @@ private:
   PodioDataSvc* m_podioDataSvc;
 
   std::map<std::string, std::string> m_cellIDEncodings{};
+  std::map<std::string, edm4hep::utils::ParticleIDMeta> m_pidMetas{};
 
   // **********************************
   // Check if a collection was already registered to skip it

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -68,6 +68,9 @@ StatusCode Lcio2EDM4hepTool::finalize() {
   for (const auto& [key, value] : m_cellIDEncodings) {
     k4FWCore::putParameter(key, value, this);
   }
+  for (const auto& [coll, pidMeta] : m_pidMetas) {
+    k4FWCore::putParameter(coll, pidMeta, this);
+  }
   return AlgTool::finalize();
 }
 
@@ -195,8 +198,6 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
   // were empty
   bool needCaloHitContribs = false;
 
-  std::map<std::string, edm4hep::utils::ParticleIDMeta> pidInfos{};
-
   for (const auto& [lcioName, edm4hepName] : collsToConvert) {
     try {
       auto* lcio_coll = the_event->getCollection(lcioName);
@@ -221,7 +222,7 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
         // Collect the ParticleID meta information because that has to go to the
         // ParticleID collections
         for (const auto& pidInfo : LCIO2EDM4hepConv::getPIDMetaInfo(lcio_coll)) {
-          pidInfos.try_emplace(LCIO2EDM4hepConv::getPIDCollName(lcioName, pidInfo.algoName), pidInfo);
+          m_pidMetas.try_emplace(LCIO2EDM4hepConv::getPIDCollName(lcioName, pidInfo.algoName), pidInfo);
         }
       }
 
@@ -238,18 +239,6 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
       warning() << "LCIO Collection " << lcioName << " not found in the event, skipping conversion to EDM4hep"
                 << endmsg;
       continue;
-    }
-  }
-
-  // Set the ParticleID meta information
-  if (m_podioDataSvc) {
-    auto& metadataFrame = m_podioDataSvc->getMetaDataFrame();
-    for (const auto& [collName, pidInfo] : pidInfos) {
-      edm4hep::utils::PIDHandler::setAlgoInfo(metadataFrame, collName, pidInfo);
-    }
-  } else {
-    for (const auto& [collName, pidInfo] : pidInfos) {
-      m_metadataSvc->put(collName, pidInfo);
     }
   }
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -247,11 +247,12 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
     for (const auto& [collName, pidInfo] : pidInfos) {
       edm4hep::utils::PIDHandler::setAlgoInfo(metadataFrame, collName, pidInfo);
     }
-  } else {
-    for (const auto& [collName, pidInfo] : pidInfos) {
-      m_metadataSvc->put(collName, pidInfo);
-    }
   }
+  // else {
+  //   for (const auto& [collName, pidInfo] : pidInfos) {
+  //     m_metadataSvc->put(collName, pidInfo);
+  //   }
+  // }
 
   auto& globalObjMap = getGlobalObjectMap(this);
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -247,12 +247,11 @@ StatusCode Lcio2EDM4hepTool::convertCollections(lcio::LCEventImpl* the_event) {
     for (const auto& [collName, pidInfo] : pidInfos) {
       edm4hep::utils::PIDHandler::setAlgoInfo(metadataFrame, collName, pidInfo);
     }
+  } else {
+    for (const auto& [collName, pidInfo] : pidInfos) {
+      m_metadataSvc->put(collName, pidInfo);
+    }
   }
-  // else {
-  //   for (const auto& [collName, pidInfo] : pidInfos) {
-  //     m_metadataSvc->put(collName, pidInfo);
-  //   }
-  // }
 
   auto& globalObjMap = getGlobalObjectMap(this);
 

--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -64,7 +64,12 @@ StatusCode Lcio2EDM4hepTool::initialize() {
   return AlgTool::initialize();
 }
 
-StatusCode Lcio2EDM4hepTool::finalize() { return AlgTool::finalize(); }
+StatusCode Lcio2EDM4hepTool::finalize() {
+  for (const auto& [key, value] : m_cellIDEncodings) {
+    k4FWCore::putParameter(key, value, this);
+  }
+  return AlgTool::finalize();
+}
 
 // **********************************
 // Check if a collection was already registered to skip it
@@ -115,8 +120,7 @@ void Lcio2EDM4hepTool::registerCollection(
           mdFrame.putParameter(podio::collMetadataParamName(name, edm4hep::labels::CellIDEncoding),
                                lcio_coll_cellid_str);
         } else {
-          k4FWCore::putParameter(podio::collMetadataParamName(name, edm4hep::labels::CellIDEncoding),
-                                 lcio_coll_cellid_str);
+          m_cellIDEncodings[podio::collMetadataParamName(name, edm4hep::labels::CellIDEncoding)] = lcio_coll_cellid_str;
         }
         debug() << "Storing CellIDEncoding " << podio::collMetadataParamName(name, edm4hep::labels::CellIDEncoding)
                 << " value: " << lcio_coll_cellid_str << endmsg;


### PR DESCRIPTION
BEGINRELEASENOTES
- Set the CellID encoding parameters at `finalize` in `Lcio2EDM4hep.cpp`

ENDRELEASENOTES

Since due to [4c89e08c2a29b4c4b3c82bac06a59797faf2dd82](https://github.com/key4hep/k4FWCore/commit/4c89e08c2a29b4c4b3c82bac06a59797faf2dd82) in k4FWCore, it is not possible to set parameters in the event loop anymore. I left the `PodioDataSvc` path as it is, since it will be removed soon.