### PR TITLE
Return when there are no input files

### DIFF
--- a/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
+++ b/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
@@ -76,6 +76,9 @@ class IOHandlerHelper:
         Args:
             input_files (list): The input files that should be read
         """
+        if not input_files:
+            return
+
         if input_files[0].endswith(".slcio"):
             if any(not f.endswith(".slcio") for f in input_files):
                 logger.error("All input files need to have the same format (LCIO)")


### PR DESCRIPTION
BEGINRELEASENOTES
- Return when there are no input files to allow using -h

ENDRELEASENOTES

Fix https://github.com/key4hep/k4MarlinWrapper/issues/474

Do you want to try it out @Victor-Schwan?

For me:
```
k4run ILDReconstruction.py -h
[k4run - INFO] io_helpers.finalize_converters: Added an input converter (EDM4hep to LCIO) to the MyAIDAProcessor algorithm
[k4run - INFO] io_helpers.finalize_converters: Added an output converter (LCIO to EDM4hep) to the CollPatcherREC algorithm
usage: k4run [--dry-run] [-n NUM_EVENTS] [-l] [--gdb] [--interactive-root] [--log-level {VERBOSE,DEBUG,INFO,WARNING,ERROR}] [-i] [--compactFile COMPACTFILE |
             --detectorModel {ILD_l5_o1_v02,ILD_l2_v02,ILD_l4_o1_v02,ILD_l4_o2_v02,ILD_l5_o1_v03,ILD_l5_o1_v04,ILD_l5_o1_v05,ILD_l5_o1_v06,ILD_l5_o2_v02,ILD_l5_o3_v02,ILD_l5_o4_v02,ILD_s2_v02,ILD_s4_o1_v02,ILD_s4_o2_v02,ILD_s5_o1_v02,ILD_s5_o1_v03,ILD_s5_o1_v04,ILD_s5_o1_v05,ILD_s5_o1_v06,ILD_s5_o2_v02,ILD_s5_o3_v02,ILD_s5_o4_v02,ILD_l5_o1_v09,ILD_l5_v11,ILD_FCCee_v01,ILD_FCCee_v02}]
             [--runBeamCalReco | --noBeamCalReco] [--inputFiles ['file1', 'file2'] [['file1', 'file2'] ...]] [--outputFileBase OUTPUTFILEBASE] [--lcioOutput {off,on,only}]
             [--cmsEnergy {91,160,240,250,350,365,500,1000}] [--perfectPFA] [--runOverlay] [--beamCalCalibFactor BEAMCALCALIBFACTOR] [--trackingOnly]
             [--MySiliconTracking_MarlinTrk.OutputLevel
...
```
It prints the options twice, once in this short version and another one with also a description when available.