### PR TITLE
Create an __init__.py file to fix the nightlies in LCG stacks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,3 +241,13 @@ add_custom_target(copy_directory ALL
   COMMENT "Copying k4MarlinWrapper python package after building all the libraries and plugins"
   DEPENDS MarlinTestProcessors
 )
+
+# Create an __init__.py in genConfDir/tests so it is treated as a regular Python
+# package and takes priority over any 'tests' package installed in site-packages
+# (e.g. from the LCG view), which would otherwise shadow GaudiTestAlgorithmsConf.
+add_custom_target(create_tests_init ALL
+  COMMAND ${CMAKE_COMMAND} -E touch
+    ${CMAKE_CURRENT_BINARY_DIR}/genConfDir/${CURRENT_DIR_NAME}/__init__.py
+  COMMENT "Creating __init__.py in genConfDir/${CURRENT_DIR_NAME} to avoid shadowing by installed 'tests' packages"
+  DEPENDS GaudiTestAlgorithms
+)


### PR DESCRIPTION
BEGINRELEASENOTES
- Create an `__init__.py` file to fix the nightlies in LCG stacks

ENDRELEASENOTES

The Python package ships a `tests` folder and this is confusing the imports, making some tests fail:

```
16: [k4run - WARNING] ConfigurableDb.getConfigurable: : Module test.GaudiTestAlgorithmsConf not found (needed for configurable MCRecoLinkChecker)
16: [k4run - WARNING] ConfigurableDb.getConfigurable: : Module test.GaudiTestAlgorithmsConf not found (needed for configurable PseudoRecoFunctional)
16: [k4run - WARNING] ConfigurableDb.getConfigurable: : Module test.GaudiTestAlgorithmsConf not found (needed for configurable PseudoRecoAlgorithm)
```

and failing later with
``` python
16: Traceback (most recent call last):
16:   File "/cvmfs/sft-nightlies.cern.ch/lcg/views/devkey-head/Sat/x86_64-el9-gcc14-opt/bin/k4run", line 292, in <module>
16:     main()
16:     ~~~~^^
16:   File "/cvmfs/sft-nightlies.cern.ch/lcg/views/devkey-head/Sat/x86_64-el9-gcc14-opt/bin/k4run", line 212, in main
16:     config_ns.update(load_file(file))
16:                      ~~~~~~~~~^^^^^^
16:   File "/cvmfs/sft-nightlies.cern.ch/lcg/views/devkey-head/Sat/x86_64-el9-gcc14-opt/python/k4FWCore/utils.py", line 95, in load_file
16:     exec(compile(code, ofile.name, "exec"), namespace)
16:     ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
16:   File "/build/jcarcell/k4MarlinWrapper/test/gaudi_opts/test_global_converter_maps.py", line 67, in <module>
16:     PseudoRecoAlg = PseudoRecoFunctional(
16:         "PseudoRecoFunctional",
16:         InputMCs=["MCParticles"],
16:         OutputRecos=["PseudoRecoParticles"],
16:     )
16: TypeError: 'NoneType' object is not callable
```

By creating an `__init__.py` first and having it in `PYTHONPATH` first, the existing local `tests` folder will be found.