### PR TITLE
Store ParticleIDMeta via MetadataSvc instead of putParameter

### DIFF
--- a/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
+++ b/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp
@@ -28,6 +28,7 @@
 #include <edm4hep/utils/ParticleIDUtils.h>
 
 #include <k4FWCore/FunctionalUtils.h>
+#include <k4FWCore/IMetadataSvc.h>
 #include <k4FWCore/MetadataUtils.h>
 
 #include "GaudiKernel/AnyDataWrapper.h"
@@ -52,8 +53,18 @@ StatusCode Lcio2EDM4hepTool::finalize() {
   for (const auto& [key, value] : m_cellIDEncodings) {
     k4FWCore::putCellIDEncoding(key, value, this);
   }
-  for (const auto& [coll, pidMeta] : m_pidMetas) {
-    k4FWCore::putParameter(coll, pidMeta, this);
+  if (!m_pidMetas.empty()) {
+    // edm4hep::utils::ParticleIDMeta is not equality comparable, so it cannot
+    // go through k4FWCore::putParameter. Store it via the dedicated
+    // IMetadataSvc::put specialization (PIDHandler::setAlgoInfo) instead.
+    auto metadataSvc = service<IMetadataSvc>("MetadataSvc", false);
+    if (!metadataSvc) {
+      error() << "MetadataSvc not found, cannot store ParticleID metadata" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    for (const auto& [coll, pidMeta] : m_pidMetas) {
+      metadataSvc->put(coll, pidMeta);
+    }
   }
   return AlgTool::finalize();
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- Store ParticleIDMeta via MetadataSvc instead of putParameter

ENDRELEASENOTES

`Lcio2EDM4hepTool::finalize()` fails to compile against current `k4FWCore@main`:
```
Lcio2EDM4hep.cpp:56:27: error: no matching function for call to 'putParameter(
..., edm4hep::utils::ParticleIDMeta, Lcio2EDM4hepTool*)'
note: candidate: template<class T, class GaudiComp>
requires equality_comparable<T> void k4FWCore::putParameter(...)
note: constraints not satisfied
```

`k4FWCore::putParameter` now carries a `std::equality_comparable<T>` constraint, so it no longer satisfies that constraint and overload resolution finds no viable candidate.

`finalize()` now retrieves the `MetadataSvc` (the same way `putParameter` does internally) and calls `put` directly. This mirrors the read side, which already uses `getParameter<edm4hep::utils::ParticleIDMeta>` in `EDM4hep2Lcio.cpp`.

## Notes
- An error is reported and `finalize()` returns `FAILURE` if the `MetadataSvc` cannot be retrieved while there is ParticleID metadata to store.
- Caught by the MuonCollider stack CI building against `k4fwcore@main` (https://github.com/MuonColliderSoft/mucoll-spack/actions/runs/27679258712).