### PR TITLE
Do not assign to nullptr inside a declareProperty call

### DIFF
--- a/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
@@ -74,8 +74,8 @@ private:
   Gaudi::Property<std::string> m_processorType{this, "ProcessorType", {}};
   Gaudi::Property<std::map<std::string, std::vector<std::string>>> m_parameters{this, "Parameters", {}};
 
-  mutable ToolHandle<IEDMConverter> m_edm_conversionTool{"IEDMConverter/EDM4hep2Lcio", this};
-  mutable ToolHandle<IEDMConverter> m_lcio_conversionTool{"IEDMConverter/Lcio2EDM4hep", this};
+  mutable ToolHandle<IEDMConverter> m_edm_conversionTool{this, "EDM4hep2LcioTool", ""};
+  mutable ToolHandle<IEDMConverter> m_lcio_conversionTool{this, "Lcio2EDM4hepTool", ""};
 
   static std::stack<marlin::Processor*>& ProcessorStack();
 

--- a/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
+++ b/k4MarlinWrapper/k4MarlinWrapper/MarlinProcessorWrapper.h
@@ -74,8 +74,8 @@ private:
   Gaudi::Property<std::string> m_processorType{this, "ProcessorType", {}};
   Gaudi::Property<std::map<std::string, std::vector<std::string>>> m_parameters{this, "Parameters", {}};
 
-  mutable ToolHandle<IEDMConverter> m_edm_conversionTool{this, "EDM4hep2LcioTool", ""};
-  mutable ToolHandle<IEDMConverter> m_lcio_conversionTool{this, "Lcio2EDM4hepTool", ""};
+  mutable ToolHandle<IEDMConverter> m_edm_conversionTool{this};
+  mutable ToolHandle<IEDMConverter> m_lcio_conversionTool{this};
 
   static std::stack<marlin::Processor*>& ProcessorStack();
 

--- a/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
+++ b/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
@@ -40,7 +40,7 @@ def _is_wrapped_proc_without_conv(alg, from_edm, to_edm):
         try:
             if not getattr(alg, f"{from_edm}2{to_edm}Tool").getName():
                 return True
-        except (AttributeError, RuntimeError):
+        except AttributeError:
             return True
 
     return False

--- a/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
+++ b/k4MarlinWrapper/python/k4MarlinWrapper/io_helpers.py
@@ -37,7 +37,10 @@ def _is_wrapped_proc_without_conv(alg, from_edm, to_edm):
     """Check if this algorithm has a configured (i.e. named) converter attached
     for the direction described by from_edm and to_edm"""
     if isinstance(alg, MarlinProcessorWrapper):
-        if not getattr(alg, f"{from_edm}2{to_edm}Tool").getName():
+        try:
+            if not getattr(alg, f"{from_edm}2{to_edm}Tool").getName():
+                return True
+        except (AttributeError, RuntimeError):
             return True
 
     return False

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -77,8 +77,8 @@ MarlinProcessorWrapper::MarlinProcessorWrapper(const std::string& name, ISvcLoca
   streamlog::out.addLevelName<streamlog::ERROR9>();
   streamlog::out.addLevelName<streamlog::SILENT>();
 
-  declareProperty("EDM4hep2LcioTool", m_edm_conversionTool = nullptr);
-  declareProperty("Lcio2EDM4hepTool", m_lcio_conversionTool = nullptr);
+  declareProperty("EDM4hep2LcioTool", m_edm_conversionTool);
+  declareProperty("Lcio2EDM4hepTool", m_lcio_conversionTool);
 }
 
 StatusCode MarlinProcessorWrapper::loadProcessorLibraries() const {

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -76,9 +76,6 @@ MarlinProcessorWrapper::MarlinProcessorWrapper(const std::string& name, ISvcLoca
   streamlog::out.addLevelName<streamlog::ERROR8>();
   streamlog::out.addLevelName<streamlog::ERROR9>();
   streamlog::out.addLevelName<streamlog::SILENT>();
-
-  declareProperty("EDM4hep2LcioTool", m_edm_conversionTool);
-  declareProperty("Lcio2EDM4hepTool", m_lcio_conversionTool);
 }
 
 StatusCode MarlinProcessorWrapper::loadProcessorLibraries() const {

--- a/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
+++ b/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp
@@ -76,6 +76,9 @@ MarlinProcessorWrapper::MarlinProcessorWrapper(const std::string& name, ISvcLoca
   streamlog::out.addLevelName<streamlog::ERROR8>();
   streamlog::out.addLevelName<streamlog::ERROR9>();
   streamlog::out.addLevelName<streamlog::SILENT>();
+
+  declareProperty("EDM4hep2LcioTool", m_edm_conversionTool, "Tool to convert EDM4hep to LCIO");
+  declareProperty("Lcio2EDM4hepTool", m_lcio_conversionTool, "Tool to convert LCIO to EDM4hep");
 }
 
 StatusCode MarlinProcessorWrapper::loadProcessorLibraries() const {


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not assign `=` in properties since it doesn't compile with newer versions of Gaudi (after 40.4, see https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1938)
- Add a check in `io_helpers.py` to catch when there is no converter, now throws an exception when the converter is not set.

ENDRELEASENOTES

Having the `= nullptr` is not allowed in Gaudi (building with the `master` branch):
```
/k4MarlinWrapper/k4MarlinWrapper/src/components/MarlinProcessorWrapper.cpp:80:60: error: use of overloaded operator '=' is ambiguous (with operand types 'ToolHandle<IEDMConverter>' and 'std::nullptr_t')
   80 |   declareProperty("EDM4hep2LcioTool", m_edm_conversionTool = nullptr);
      |                                       ~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~
/Gaudi/install/include/GaudiKernel/GaudiHandle.h:159:20: note: candidate function
  159 |   GaudiHandleBase& operator=( const std::string& typeAndName ) {
      |                    ^
/Gaudi/install/include/GaudiKernel/GaudiHandle.h:165:20: note: candidate function
  165 |   GaudiHandleBase& operator=( std::string&& typeAndName ) {
      |                    ^
/Gaudi/install/include/GaudiKernel/ToolHandle.h:132:7: note: candidate function (the implicit copy assignment operator)
  132 | class ToolHandle : public BaseToolHandle, public GaudiHandle<T> {
      |       ^
```

and it's not clear what the assignment does. The default is already set by the default name.